### PR TITLE
fix(ci): apply AR encryption env fallback after initialize

### DIFF
--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -8,21 +8,28 @@
 # blank and credentials decrypt to nil — which then 500s any controller
 # that touches a model with `encrypts` (e.g. `devise-two-factor`'s
 # `otp_secret`). This env-var fallback lets those CI runs boot Rails
-# with throwaway keys. Real environments override neither path because
-# the env vars aren't set; credentials win.
+# with throwaway keys.
+#
+# The fallback runs in `after_initialize` and mutates the already-built
+# `ActiveRecord::Encryption.config` because Rails applies encryption
+# config from credentials inside an `on_load(:active_record_encryption)`
+# hook that fires *before* `config/initializers/*` load — assigning to
+# `config.active_record.encryption.*` here would be too late to reach it.
+# We only fill keys credentials left blank, so real environments keep
+# using their credential-backed keys untouched.
 
-primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
-deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
-key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
+Rails.application.config.after_initialize do
+  encryption = ActiveRecord::Encryption.config
 
-if primary_key.present?
-  Rails.application.config.active_record.encryption.primary_key = primary_key
-end
-
-if deterministic_key.present?
-  Rails.application.config.active_record.encryption.deterministic_key = deterministic_key
-end
-
-if key_derivation_salt.present?
-  Rails.application.config.active_record.encryption.key_derivation_salt = key_derivation_salt
+  # `has_*?` reads the raw ivar (`.presence`); the plain readers raise when a
+  # key is blank, so we must not touch them before deciding to fall back.
+  unless encryption.has_primary_key?
+    encryption.primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"].presence
+  end
+  unless encryption.has_deterministic_key?
+    encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"].presence
+  end
+  unless encryption.has_key_derivation_salt?
+    encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"].presence
+  end
 end


### PR DESCRIPTION
## Why

Dependabot (and fork) CI runs don't inherit `RAILS_MASTER_KEY`, so `config/credentials.yml.enc` decrypts to `nil`. The e2e job provides throwaway ActiveRecord encryption keys via env vars as a fallback, but the fallback wasn't taking effect — every dependabot PR's `e2e-tests` job failed with:

```
Missing Active Record encryption credential: active_record_encryption.primary_key
```

## Root cause

The fallback lived in `config/initializers/active_record_encryption.rb` and assigned to `config.active_record.encryption.*`. Rails applies encryption config inside an `on_load(:active_record_encryption)` hook that fires **before** `config/initializers/*` are loaded, so the assignment never reached `ActiveRecord::Encryption.config`. The keys stayed `nil`, and any controller touching an `encrypts` attribute (e.g. devise-two-factor's `otp_secret`, hit during the login e2e specs) 500s.

## Fix

Move the fallback into `after_initialize` and mutate the already-built `ActiveRecord::Encryption.config` directly, filling **only** the keys credentials left blank (guarded via the `has_*?` predicates, since the plain readers raise on blank). Real environments with `RAILS_MASTER_KEY` keep using their credential-backed keys untouched.

## Verification

Locally simulated both paths (temporarily removing `config/master.key` for the no-secret case):

- **Credentials present** → keys resolve to the credential values (fallback is a no-op). ✅
- **No master key** → keys resolve to the env values and a real `encrypt` succeeds instead of raising. ✅

The definitive proof is dependabot's own (secret-less) `e2e-tests` job going green once this lands on `main`.
🤖