### PR TITLE
fix(ci): install Playwright browser matching the npm version in e2e

### DIFF
--- a/.github/workflows/e2e-tests.job.yml
+++ b/.github/workflows/e2e-tests.job.yml
@@ -69,6 +69,12 @@ jobs:
         with:
           bundler-cache: true
       - uses: ./.github/workflows/js-setup-action
+      # Install the browser build that matches the installed @playwright/test
+      # version. The container ships browsers for its own Playwright version,
+      # so a Dependabot bump of the npm package would otherwise fail with
+      # "Executable doesn't exist" until the image tag is bumped in lockstep.
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
       - run: mkdir -p log && mkdir -p tmp/pids && rm -f tmp/pids/*
       - name: Setup DB
         run: bundle exec rails db:create db:schema:load


### PR DESCRIPTION
## Why

The npm patch/minor Dependabot group (#932) bumps `@playwright/test` `1.60.0 → 1.62.1`, and its `e2e-tests` job fails with:

```
browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-.../chrome-headless-shell
```

The e2e job runs inside `mcr.microsoft.com/playwright:v1.60.0-noble`, whose browsers are pinned to Playwright 1.60. When the npm package moves ahead of the image, the baked-in browser build no longer matches and Playwright can't find an executable.

Bumping the container image tag in lockstep with every `@playwright/test` bump is brittle (image + npm version can't be changed atomically across separate PRs on `main`).

## Fix

Add a step that runs `pnpm exec playwright install --with-deps chromium` after JS deps are installed, so the browser build always matches the installed `@playwright/test` version regardless of the container image tag. This unblocks #932 and prevents the same breakage on future Playwright bumps.

## Verification

- No-op on `main` today (npm 1.60.0 → installs the 1.60 build already present in the image; e2e stays green).
- After rebasing #932 onto this, the 1.62.1 Chromium build installs and the e2e specs run.
🤖