### PR TITLE
chore: replace deprecated dotenv/rails-now require

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ group :development do
   gem "standard"
 
   gem "dotenv"
-  gem "dotenv-rails", require: "dotenv/rails-now"
+  gem "dotenv-rails", require: "dotenv/load"
 
   gem "spring"
   gem "spring-watcher-listen"


### PR DESCRIPTION
## Why

Booting on dotenv 3.x logs:

```
[DEPRECATION] `require "dotenv/rails-now"` is deprecated. Use `require "dotenv/load"` instead.
```

## Change

`gem "dotenv-rails", require: "dotenv/rails-now"` → `require: "dotenv/load"`. This preserves the early (pre-initializer) `.env` loading the app depends on for boot-time config (e.g. `DB_PORT`); the app only has a single `.env`, so Rails-env-specific file resolution isn't in play.

## Verification

- Boot: deprecation warning gone; `.env` still resolves `DB_PORT`/`REDIS_URL` without them being passed explicitly.
- Full Minitest suite green: 116 runs, 0 failures, 0 errors.
🤖