### PR TITLE
chore: adopt Rails 8.1 framework defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ Bundler.require(*Rails.groups)
 module Reckoning
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 8.1
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
Follow-up to the Rails 8.1 upgrade (#938). Moves `config.load_defaults 7.0` → `8.1`.

## Audit of the flipped defaults (7.0 → 8.1)

Checked the behavior-changing defaults against this app:

- **`cookies_serializer` (:marshal → :json)** — no-op: the app already sets `:json` explicitly in `config/initializers/cookies_serializer.rb` (and `load_defaults` never overrides explicit config). No session/cookie invalidation.
- **`default_column_serializer` (→ nil, 7.1)** — safe: no bare `serialize :col` in models; only `store_accessor` on jsonb columns, which is unaffected.
- **No `Marshal` usage**; `yaml_column_permitted_classes` already configured.
- **8.1-specific defaults** are minor (JSON escaping perf, order-dependent finder raises).

## ⚠️ One deploy-time consideration

`cache_format_version` isn't pinned, so it adopts the 8.1 format. Existing Redis cache entries written in the old format are **ignored and repopulated** — a graceful one-time cold cache after deploy (no errors, no data loss). If a cold cache is undesirable at deploy time, we can pin `config.active_support.cache_format_version = 7.0` and lift it later.

## Verification

- Full Minitest suite green under `load_defaults 8.1`: **116 runs, 242 assertions, 0 failures, 0 errors, 5 skips**.
- Boots in `test` and `development`; `Rails.cache` write→read round-trips against Redis under the 8.1 cache format.

🤖