### PR TITLE
fix(noty): stop overriding window.confirm so confirm dialogs are actually awaited

### DIFF
--- a/.github/workflows/e2e-tests.job.yml
+++ b/.github/workflows/e2e-tests.job.yml
@@ -37,12 +37,12 @@ jobs:
       RAILS_SERVE_STATIC_FILES: 1
       DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
       JOBS: 1
-      PORT: 8270
-      PLAYWRIGHT_BASE_URL: http://localhost:8270
+      PORT: 8250
+      PLAYWRIGHT_BASE_URL: http://localhost:8250
       # Same-origin API base path for the Vue islands (ApiBasePath is
       # `//<app.domain>`); without this it defaults to `reckoning.test`,
       # which the browser can't resolve in CI.
-      DOMAIN: localhost:8270
+      DOMAIN: localhost:8250
       NODE_OPTIONS: "--max_old_space_size=4096"
 
     services:

--- a/app/assets/javascripts/angular/base/controllers/timerModal.coffee
+++ b/app/assets/javascripts/angular/base/controllers/timerModal.coffee
@@ -75,7 +75,7 @@ angular.module 'Reckoning'
           selectize.addItem newTask.id
 
     $scope.delete = (timer) ->
-      confirm I18n.t('messages.confirm.timesheet.delete_timer'), ->
+      notyConfirm I18n.t('messages.confirm.timesheet.delete_timer'), ->
         Timer.delete(timer.id).success (data) ->
           $uibModalInstance.close({data: data, status: 'deleted'})
 

--- a/app/assets/javascripts/angular/timesheet/controllers/task.coffee
+++ b/app/assets/javascripts/angular/timesheet/controllers/task.coffee
@@ -80,7 +80,7 @@ angular.module 'Timesheet'
       sum
 
     $scope.removeTask = (task) ->
-      confirm I18n.t('messages.confirm.timesheet.delete_task'), ->
+      notyConfirm I18n.t('messages.confirm.timesheet.delete_task'), ->
         task.timers.forEach (timer) ->
           if timer.id
             Timer.delete(timer.id)

--- a/app/assets/javascripts/helpers/noty.coffee
+++ b/app/assets/javascripts/helpers/noty.coffee
@@ -12,7 +12,13 @@ window.displayNoty = (text, type, timeout = 3000) ->
       speed: 500
     progressBar: true
 
-window.confirm = (message, okCallback, cancelCallback) ->
+# Callback-based confirm dialog. Deliberately NOT `window.confirm`:
+# this returns the noty object immediately instead of blocking, so
+# overriding the native one silently defeated every caller written as
+# `if (!confirm(msg)) return` — the action ran while the dialog was
+# still on screen. `app/frontend/lib/confirm.ts` wraps this in a
+# promise for the Vue islands.
+window.notyConfirm = (message, okCallback, cancelCallback) ->
   okButton =
     addClass: 'btn btn-primary'
     text: I18n.t('actions.ok')
@@ -28,7 +34,7 @@ window.confirm = (message, okCallback, cancelCallback) ->
     onClick: ($noty) ->
       $noty.close()
       if cancelCallback isnt undefined && _.isFunction(cancelCallback)
-        cancelCallBack()
+        cancelCallback()
       return false
 
   noty
@@ -36,6 +42,11 @@ window.confirm = (message, okCallback, cancelCallback) ->
     buttons: [okButton, cancelButton]
     layout: 'bottom'
     theme: 'metroui'
+    # Only the buttons dismiss this dialog. noty's default
+    # `closeWith: ['click']` let a click anywhere on the bar close it
+    # without running either callback, which leaves a promise-wrapped
+    # caller waiting forever.
+    closeWith: []
     animation:
       open: 'animated fadeInUp'
       close: 'animated fadeOutDown'

--- a/app/frontend/islands/timers-calendar/components/TimerModal.vue
+++ b/app/frontend/islands/timers-calendar/components/TimerModal.vue
@@ -7,6 +7,7 @@ import {computed, onBeforeUnmount, onMounted, ref, watch} from "vue"
 import {formatHHMM, parseHHMM, runningDuration} from "../../../lib/timers/format"
 import {createTask, createTimer, deleteTimer, startTimer, stopTimer, updateTimer} from "../../../lib/timers/api"
 import type {Task, Timer} from "../../../lib/timers/types"
+import {confirmDialog} from "../../../lib/confirm"
 
 const props = defineProps<{
   draft: Partial<Timer> & {date: string; projectId: string}
@@ -130,7 +131,7 @@ async function onStop() {
 
 async function onDelete() {
   if (!id.value) return
-  if (!window.confirm("Delete this timer?")) return
+  if (!(await confirmDialog("Delete this timer?"))) return
   saving.value = true
   try {
     await deleteTimer(id.value)

--- a/app/frontend/islands/timesheet/components/TimerModal.vue
+++ b/app/frontend/islands/timesheet/components/TimerModal.vue
@@ -18,6 +18,7 @@ import {
   updateTimer,
 } from "../../../lib/timers/api"
 import type {Project, Task, Timer} from "../../../lib/timers/types"
+import {confirmDialog} from "../../../lib/confirm"
 
 const props = defineProps<{
   draft: Partial<Timer> & {date: string}
@@ -160,7 +161,7 @@ async function onStop() {
 
 async function onDelete() {
   if (!id.value) return
-  if (!window.confirm("Diese Zeit löschen?")) return
+  if (!(await confirmDialog("Diese Zeit löschen?"))) return
   saving.value = true
   try {
     await deleteTimer(id.value)

--- a/app/frontend/islands/timesheet/components/WeekGrid.spec.ts
+++ b/app/frontend/islands/timesheet/components/WeekGrid.spec.ts
@@ -4,11 +4,12 @@ import type {Timer} from "../../../lib/timers/types"
 import type {TaskWithTimers} from "../../../lib/timers/api"
 
 // Spies shared with the mocked modules (hoisted above the imports).
-const {refresh, createTimer, updateTimer, deleteTimer} = vi.hoisted(() => ({
+const {refresh, createTimer, updateTimer, deleteTimer, confirmDialog} = vi.hoisted(() => ({
   refresh: vi.fn(),
   createTimer: vi.fn(() => Promise.resolve({})),
   updateTimer: vi.fn(() => Promise.resolve({})),
   deleteTimer: vi.fn(() => Promise.resolve()),
+  confirmDialog: vi.fn(() => Promise.resolve(true)),
 }))
 
 vi.mock("../composables/useWeekTasks", async () => {
@@ -33,6 +34,7 @@ vi.mock("../composables/useWeekTasks", async () => {
 })
 
 vi.mock("../../../lib/timers/api", () => ({createTimer, updateTimer, deleteTimer}))
+vi.mock("../../../lib/confirm", () => ({confirmDialog}))
 
 import WeekGrid from "./WeekGrid.vue"
 import WeekCell from "./WeekCell.vue"
@@ -76,7 +78,7 @@ function mountGrid(extraTasks?: TaskWithTimers[]) {
   })
 }
 
-function makeRow(id: string): TaskWithTimers {
+function makeRow(id: string, timers: Timer[] = []): TaskWithTimers {
   return {
     id,
     name: "Task",
@@ -85,7 +87,7 @@ function makeRow(id: string): TaskWithTimers {
     projectId: "p1",
     projectName: "Project",
     projectCustomerName: null,
-    timers: [],
+    timers,
   }
 }
 
@@ -108,6 +110,42 @@ describe("WeekGrid rows", () => {
     const wrapper = mountGrid([makeRow("task1")])
 
     expect(wrapper.findAll(".panel.panel-default")).toHaveLength(1)
+  })
+})
+
+describe("WeekGrid row removal", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  // Row 0 is the fetched task, row 1 the extra one passed in below.
+  async function clickRemove(wrapper: ReturnType<typeof mountGrid>) {
+    await wrapper.findAll(".timesheet-task-actions button")[1].trigger("click")
+    await flushPromises()
+  }
+
+  it("deletes nothing until the confirm is answered", async () => {
+    let answer: (ok: boolean) => void = () => {}
+    confirmDialog.mockReturnValueOnce(new Promise<boolean>((resolve) => (answer = resolve)))
+    const wrapper = mountGrid([makeRow("task2", [makeTimer({id: "x"})])])
+
+    await clickRemove(wrapper)
+    expect(deleteTimer).not.toHaveBeenCalled()
+    expect(wrapper.emitted("removeTask")).toBeUndefined()
+
+    answer(true)
+    await flushPromises()
+    expect(deleteTimer).toHaveBeenCalledWith("x")
+    expect(wrapper.emitted("removeTask")).toHaveLength(1)
+  })
+
+  it("keeps the row when the confirm is cancelled", async () => {
+    confirmDialog.mockResolvedValueOnce(false)
+    const wrapper = mountGrid([makeRow("task2", [makeTimer({id: "x"})])])
+
+    await clickRemove(wrapper)
+
+    expect(deleteTimer).not.toHaveBeenCalled()
+    expect(refresh).not.toHaveBeenCalled()
+    expect(wrapper.emitted("removeTask")).toBeUndefined()
   })
 })
 

--- a/app/frontend/islands/timesheet/components/WeekGrid.vue
+++ b/app/frontend/islands/timesheet/components/WeekGrid.vue
@@ -18,6 +18,7 @@ import dayjs from "dayjs"
 import {useWeekTasks} from "../composables/useWeekTasks"
 import {weekDays, formatHHMM, ISO_DATE, todayISO} from "../../../lib/timers/format"
 import {createTimer, updateTimer, deleteTimer, type TaskWithTimers} from "../../../lib/timers/api"
+import {confirmDialog} from "../../../lib/confirm"
 import type {Timer} from "../../../lib/timers/types"
 import WeekCell from "./WeekCell.vue"
 
@@ -109,7 +110,7 @@ async function onCellSave(payload: {
 }
 
 async function onTaskRemove(task: TaskWithTimers) {
-  if (!window.confirm("Aufgabe und alle Zeiten dieser Woche löschen?")) return
+  if (!(await confirmDialog("Aufgabe und alle Zeiten dieser Woche löschen?"))) return
   try {
     for (const t of task.timers) {
       if (t.id) await deleteTimer(t.id)

--- a/app/frontend/lib/confirm.spec.ts
+++ b/app/frontend/lib/confirm.spec.ts
@@ -1,0 +1,63 @@
+import {describe, it, expect, afterEach, vi} from "vitest"
+import {confirmDialog} from "./confirm"
+
+interface ConfirmGlobals {
+  notyConfirm?: unknown
+}
+
+const globals = window as unknown as ConfirmGlobals
+
+afterEach(() => {
+  delete globals.notyConfirm
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("confirmDialog", () => {
+  it("stays pending until the noty dialog is answered", async () => {
+    let ok: () => void = () => {}
+    globals.notyConfirm = vi.fn((_message: string, okCallback: () => void) => {
+      ok = okCallback
+    })
+
+    const settled = vi.fn()
+    const answer = confirmDialog("Delete?").then(settled)
+
+    await Promise.resolve()
+    expect(settled).not.toHaveBeenCalled()
+
+    ok()
+    await expect(answer).resolves.toBe(undefined)
+    expect(settled).toHaveBeenCalledWith(true)
+  })
+
+  it("resolves false when the dialog is cancelled", async () => {
+    globals.notyConfirm = (_message: string, _ok: () => void, cancel: () => void) => cancel()
+
+    await expect(confirmDialog("Delete?")).resolves.toBe(false)
+  })
+
+  it("ignores a second answer from the same dialog", async () => {
+    let ok: () => void = () => {}
+    let cancel: () => void = () => {}
+    globals.notyConfirm = (_m: string, okCallback: () => void, cancelCallback: () => void) => {
+      ok = okCallback
+      cancel = cancelCallback
+    }
+
+    const answer = confirmDialog("Delete?")
+    ok()
+    cancel()
+
+    await expect(answer).resolves.toBe(true)
+  })
+
+  it("falls back to the native dialog when noty is absent", async () => {
+    // happy-dom has no window.confirm of its own to spy on.
+    const native = vi.fn(() => false)
+    vi.stubGlobal("confirm", native)
+
+    await expect(confirmDialog("Delete?")).resolves.toBe(false)
+    expect(native).toHaveBeenCalledWith("Delete?")
+  })
+})

--- a/app/frontend/lib/confirm.ts
+++ b/app/frontend/lib/confirm.ts
@@ -1,0 +1,33 @@
+// Awaitable confirm for the Vue islands.
+//
+// The legacy Sprockets bundle ships `window.notyConfirm` (see
+// `app/assets/javascripts/helpers/noty.coffee`) — a noty dialog that
+// takes ok/cancel callbacks and returns straight away. Islands render
+// inside that layout, so prefer it for a consistent look and wrap it
+// in a promise; outside it (tests, a future standalone page) fall back
+// to the blocking native dialog.
+
+type NotyConfirm = (message: string, ok: () => void, cancel: () => void) => unknown
+
+interface ConfirmGlobals {
+  notyConfirm?: NotyConfirm
+}
+
+export function confirmDialog(message: string): Promise<boolean> {
+  const notyConfirm = (window as unknown as ConfirmGlobals).notyConfirm
+  if (typeof notyConfirm !== "function") return Promise.resolve(window.confirm(message))
+
+  return new Promise((resolve) => {
+    let settled = false
+    const settle = (answer: boolean) => {
+      if (settled) return
+      settled = true
+      resolve(answer)
+    }
+    notyConfirm(
+      message,
+      () => settle(true),
+      () => settle(false),
+    )
+  })
+}

--- a/config/initializers/cypress_on_rails.rb
+++ b/config/initializers/cypress_on_rails.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # cypress-on-rails wires Playwright (or Cypress) specs to Rails-side
-# helpers. The middleware is mounted in non-production envs and
+# helpers. The middleware is mounted in the test env only and
 # accepts POSTs that dispatch to ruby files under
 # `test/e2e/app_commands/`: DB cleaning, scenario seeding, ad-hoc
 # `eval`, plus the per-failure log capture.
@@ -13,7 +13,10 @@ if defined?(CypressOnRails)
   CypressOnRails.configure do |c|
     c.api_prefix = ""
     c.install_folder = Rails.root.join("test", "e2e").to_s
-    c.use_middleware = !Rails.env.production?
+    # Test env only: the middleware dispatches arbitrary app commands (incl. a
+    # truncating DB clean) at the app root, so a dev server on a port another
+    # app's e2e suite targets would wipe the dev database.
+    c.use_middleware = Rails.env.test?
     c.logger = Rails.logger
   end
 end

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,10 @@ import { defineConfig } from "@playwright/test"
 // Minitest suite (this app uses Minitest, not RSpec). `data-test`
 // is the testId attribute. `webServer` boots Puma so
 // `pnpm test:e2e:run` works the same way locally and in CI.
-const port = Number(process.env.PORT ?? 8270)
+// Keep the e2e port inside this app's own block (dev 8240, PG 8241,
+// Redis 8242): `reuseExistingServer` below attaches to whatever already
+// listens here, so a port another app owns runs the suite against that app.
+const port = Number(process.env.PORT ?? 8250)
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${port}`
 
 export default defineConfig({
@@ -25,6 +28,13 @@ export default defineConfig({
   },
   webServer: {
     command: "pnpm test:e2e:startserver",
+    // Puma reads PORT (config/puma.rb) and the islands build ApiBasePath
+    // from DOMAIN, so both have to match the port we poll — otherwise the
+    // server comes up somewhere else and the API calls leave the host.
+    env: {
+      PORT: String(port),
+      DOMAIN: process.env.DOMAIN ?? `localhost:${port}`,
+    },
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     stdout: "pipe",

--- a/test/e2e/Timesheet.spec.ts
+++ b/test/e2e/Timesheet.spec.ts
@@ -33,6 +33,24 @@ test.describe("Timesheet week view", () => {
     await expect(row.locator(".timesheet-row-sum")).toContainText("1:00")
   })
 
+  test("removes a row only after the confirm is accepted", async ({page, confirm}) => {
+    await signIn(page)
+    await page.goto("/timesheet?view=week")
+
+    const row = page.locator(".panel").filter({hasText: "E2E Task"})
+    await expect(row).toBeVisible()
+
+    await row.locator(".timesheet-task-actions button").click()
+    await confirm.cancel()
+    await expect(row).toBeVisible()
+    await expect(row.locator(".timesheet-row-sum")).toContainText("1:00")
+    await confirm.waitForClosed()
+
+    await row.locator(".timesheet-task-actions button").click()
+    await confirm.accept()
+    await expect(row).toHaveCount(0)
+  })
+
   test("autosaves a cell edit and recomputes the row total", async ({page}) => {
     await signIn(page)
     await page.goto("/timesheet?view=week")

--- a/test/e2e/support/commands/confirm.ts
+++ b/test/e2e/support/commands/confirm.ts
@@ -1,25 +1,38 @@
 import { type Page } from "@playwright/test"
 
-// Reckoning has two confirm flows:
+// Reckoning has two confirm flows, both rendered by noty's `bottom`
+// layout (`ul#noty_bottom_layout_container`) with OK / Cancel as
+// `.noty_buttons button:{first,last}-child`:
 //
 // 1. `[data-notyConfirm]` — the legacy CoffeeScript handler in
-//    app/assets/javascripts/helpers/noty.coffee shows a noty bottom-
-//    layout dialog with OK / Cancel buttons rendered as
-//    `#noty-confirm .noty_buttons button:{first,last}-child`.
+//    app/assets/javascripts/helpers/noty.coffee.
+// 2. `window.notyConfirm(message, ok, cancel)` — the same dialog
+//    called directly, including from the Vue islands via
+//    `app/frontend/lib/confirm.ts`.
 //
-// 2. `data-turbo-confirm` — Turbo's native confirm uses `window.confirm`
-//    by default. If we ever wire it up via `Turbo.setConfirmMethod`
-//    to a custom dialog, add a helper here.
-//
-// This class targets the legacy noty flow that's actually in use today.
+// `data-turbo-confirm` uses the native `window.confirm` instead; drive
+// that with `page.on("dialog", …)`.
 export default class Confirm {
+  private readonly dialogs = "#noty_bottom_layout_container .noty_bar"
+
   constructor(private readonly page: Page) {}
 
+  // noty only drops a bar once its fade-out finishes, so an
+  // already-answered dialog can still be in the DOM — always act on the
+  // newest one.
+  private get dialog() {
+    return this.page.locator(this.dialogs).last()
+  }
+
   async accept() {
-    await this.page.locator("#noty-confirm .noty_buttons button:first-child").click()
+    await this.dialog.locator(".noty_buttons button").first().click()
   }
 
   async cancel() {
-    await this.page.locator("#noty-confirm .noty_buttons button:last-child").click()
+    await this.dialog.locator(".noty_buttons button").last().click()
+  }
+
+  async waitForClosed() {
+    await this.page.locator(this.dialogs).first().waitFor({ state: "detached" })
   }
 }


### PR DESCRIPTION
Reported as "when I remove a row in timesheet the confirm is useless because the
row removes without waiting for the confirmation". The timesheet code was fine —
`window.confirm` was not.

## What was broken

`helpers/noty.coffee` replaced the **native** `window.confirm` with a
callback-based noty dialog:

```coffee
window.confirm = (message, okCallback, cancelCallback) -> ... noty {...}
```

That function does not block and returns the noty object, which is truthy. So
every caller written the normal way —

```ts
if (!window.confirm("Aufgabe und alle Zeiten dieser Woche löschen?")) return
```

— sailed straight through the guard, deleted the timers, and re-fetched the
grid while the dialog was still on screen. Answering it did nothing either way.
Same family as #940's `c979f5eb` (act before the confirm is answered), one layer
lower: there it was handler ordering, here the guard itself was never a guard.

Three island call sites were affected — `WeekGrid` row removal (the report),
`timesheet/TimerModal`, `timers-calendar/TimerModal`.

Found while in there:

- **Turbo's `data-turbo-confirm` was broken the same way.** Turbo calls
  `window.confirm` and expects a boolean, so the expenses bulk delete
  (`expenses/index.html.erb:113`) deleted immediately, unprompted.
- **Cancel threw.** `cancelCallBack()` was a typo for `cancelCallback` — a
  `ReferenceError` on every cancel of the two legacy Angular confirms.
- **The e2e `Confirm` helper targeted `#noty-confirm`**, which nothing renders;
  noty's bottom layout is `ul#noty_bottom_layout_container`. No spec used the
  fixture yet, so it had never run.

## Changes

- `helpers/noty.coffee` — dialog moves to `window.notyConfirm`; the native
  `confirm` is left alone. Fixes the `cancelCallback` typo, and sets
  `closeWith: []` so only OK/Cancel dismiss it (noty's default let a click
  anywhere on the bar close it without running either callback, which would
  leave a promise-wrapped caller pending forever).
- `app/frontend/lib/confirm.ts` (new) — `confirmDialog(message)` wraps
  `notyConfirm` in a promise, falling back to the native dialog outside the
  legacy bundle. The three island call sites now `await` it.
- `timesheet/controllers/task.coffee`, `base/controllers/timerModal.coffee` —
  renamed to `notyConfirm`, the only two legacy callers.
- `test/e2e/support/commands/confirm.ts` — real selectors, and it acts on the
  newest bar since noty keeps an answered one in the DOM until its fade-out
  finishes.

Second commit is unrelated plumbing that blocked running the suite locally: the
default e2e port was **8270**, which another app on this machine uses for its dev
server — `reuseExistingServer` silently attached to it and failed on foreign
scenario paths. Moved to **8250**, inside this app's own block (dev 8240, PG
8241, Redis 8242), and `webServer` now passes `PORT` (puma read it from the
ambient env, so the config default only worked if you exported `PORT` yourself)
plus `DOMAIN` (the islands build `ApiBasePath` from it; without it the API calls
leave the host). CI's port is aligned with the new default.

## Verification

31/31 vitest — 4 new for `confirmDialog` (stays pending until answered, resolves
true/false, ignores a double answer, native fallback) and 2 new for `WeekGrid`
(`deleteTimer` not called until the confirm resolves; cancel deletes nothing).

3/3 Playwright `Timesheet.spec.ts`, including a new spec that cancels (row and
its 1:00 total survive) then accepts (row goes). The two pre-existing specs pass
unchanged.

Not exercised locally: the CI port change. `PORT`, `PLAYWRIGHT_BASE_URL` and
`DOMAIN` are set consistently and the job's container has no other listener on
8250, so it should be a no-op.

🤖
