### PR TITLE
fix: puma worker boot on YAML aliases, and the Redis database limit

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -34,5 +34,9 @@ on_worker_boot do
 
   require "erb"
 
-  ActiveRecord::Base.establish_connection(YAML.safe_load(ERB.new(File.read("#{app_dir}/config/database.yml")).result)[rails_environment])
+  # database.yml merges the production anchor into every other environment, so
+  # safe_load needs aliases enabled.
+  database_config = YAML.safe_load(ERB.new(File.read("#{app_dir}/config/database.yml")).result, aliases: true)
+
+  ActiveRecord::Base.establish_connection(database_config[rails_environment])
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       - postgres:/var/lib/postgresql/data
   redis:
     image: redis:7.4-alpine
+    # bin/setup gives each worktree its own Redis DB index (up to 501), well past
+    # the default limit of 16.
+    command: redis-server --databases 512
     ports:
       - 8242:6379
     volumes:


### PR DESCRIPTION
Two fixes recovered from the vue-spa worktree, which was deleted automatically when #955 merged before they were committed.

### `config/puma.rb` — worker boot raises

`on_worker_boot` re-parses `database.yml` to re-establish the connection. That file anchors `production: &default` and merges it into staging, development and test, but `YAML.safe_load` refuses aliases unless asked:

```
Psych::AliasesNotEnabled: Alias parsing was not enabled.
```

Reproduced directly against the committed `database.yml`.

This only bites in **cluster mode** — `on_worker_boot` does not run with `WORKER_COUNT=0`, which is what the test and e2e setups use, so nothing in CI ever executed the block.

### `docker-compose.yml` — Redis database limit

`bin/setup` assigns each worktree its own Redis DB index, which climbs past Redis's default limit of 16 and fails to select once enough worktrees exist. Raised to 512.

---

Verified: `standardrb` clean, `docker-compose.yml` parses, and the aliases fix confirmed to load all four environments.

🤖