### PR TITLE
feat(api): add the confirmation and unlock endpoints

### DIFF
--- a/app/api_components/v1/schemas/inputs/confirmation_input.rb
+++ b/app/api_components/v1/schemas/inputs/confirmation_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class ConfirmationInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            confirmation_token: {type: :string, description: "From the confirmation email."}
+          },
+          additionalProperties: false,
+          required: %w[confirmation_token]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/confirmation_request_input.rb
+++ b/app/api_components/v1/schemas/inputs/confirmation_request_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class ConfirmationRequestInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            email: {type: :string}
+          },
+          additionalProperties: false,
+          required: %w[email]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/unlock_input.rb
+++ b/app/api_components/v1/schemas/inputs/unlock_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class UnlockInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            unlock_token: {type: :string, description: "From the unlock email."}
+          },
+          additionalProperties: false,
+          required: %w[unlock_token]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/unlock_request_input.rb
+++ b/app/api_components/v1/schemas/inputs/unlock_request_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class UnlockRequestInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            email: {type: :string}
+          },
+          additionalProperties: false,
+          required: %w[email]
+        })
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/confirmations_controller.rb
+++ b/app/controllers/api/v1/confirmations_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Email confirmation. `reconfirmable` is on, so this also serves an address
+    # change, not just signup.
+    class ConfirmationsController < ::Api::BaseController
+      skip_authorization_check
+      skip_before_action :authenticate_user!
+      skip_forgery_protection
+
+      # Always reports success: whether an address has an account is not
+      # something an unauthenticated caller should be able to probe.
+      def create
+        User.send_confirmation_instructions(email: confirmation_request_params[:email])
+
+        render json: {message: I18n.t("devise.confirmations.send_paranoid_instructions")}
+      end
+
+      def update
+        @user = User.confirm_by_token(confirmation_params[:confirmation_token])
+
+        if @user.errors.empty?
+          render json: {message: I18n.t("devise.confirmations.confirmed")}
+        else
+          render json: ValidationError.new("confirmation.update", @user.errors), status: :bad_request
+        end
+      end
+
+      private def confirmation_request_params
+        @confirmation_request_params ||= openapi_params(::V1::Schemas::Inputs::ConfirmationRequestInput)
+      end
+
+      private def confirmation_params
+        @confirmation_params ||= openapi_params(::V1::Schemas::Inputs::ConfirmationInput)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/unlocks_controller.rb
+++ b/app/controllers/api/v1/unlocks_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Account lockout. `lock_strategy` is `:failed_attempts` and
+    # `unlock_strategy` is `:email`, so this is the only way back in for a
+    # locked account.
+    class UnlocksController < ::Api::BaseController
+      skip_authorization_check
+      skip_before_action :authenticate_user!
+      skip_forgery_protection
+
+      # Always reports success: whether an address has an account is not
+      # something an unauthenticated caller should be able to probe.
+      def create
+        User.send_unlock_instructions(email: unlock_request_params[:email])
+
+        render json: {message: I18n.t("devise.unlocks.send_paranoid_instructions")}
+      end
+
+      def update
+        @user = User.unlock_access_by_token(unlock_params[:unlock_token])
+
+        if @user.errors.empty?
+          render json: {message: I18n.t("devise.unlocks.unlocked")}
+        else
+          render json: ValidationError.new("unlock.update", @user.errors), status: :bad_request
+        end
+      end
+
+      private def unlock_request_params
+        @unlock_request_params ||= openapi_params(::V1::Schemas::Inputs::UnlockRequestInput)
+      end
+
+      private def unlock_params
+        @unlock_params ||= openapi_params(::V1::Schemas::Inputs::UnlockInput)
+      end
+    end
+  end
+end

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -54,6 +54,10 @@ de:
       update: "Profil konnte nicht gespeichert werden."
     password:
       update: "Passwort konnte nicht geändert werden."
+    confirmation:
+      update: "E-Mail-Adresse konnte nicht bestätigt werden."
+    unlock:
+      update: "Konto konnte nicht entsperrt werden."
     otp:
       invalid_attempt: "Der eingegebene Code ist ungültig."
       not_enabled: "Zwei-Faktor-Authentifizierung ist nicht aktiviert."

--- a/config/routes/api_v1_routes.rb
+++ b/config/routes/api_v1_routes.rb
@@ -7,6 +7,10 @@ v1_api_routes = lambda do
 
   resource :passwords, only: %i[create update]
 
+  resource :confirmations, only: %i[create update]
+
+  resource :unlocks, only: %i[create update]
+
   resource :me, only: %i[show update], controller: :me do
     patch :password, action: :update_password
   end

--- a/docs/vue-spa-migration-plan.md
+++ b/docs/vue-spa-migration-plan.md
@@ -477,13 +477,14 @@ fetch boundary, which is why `types.ts` can legitimately declare `number`.
 When B4 moves the timesheet onto the generated client, that coercion has to
 move with it — the generated types will say `string`, correctly.
 
-### Phase A3–A8 — API buildout ✅ complete (70 operations)
+### Phase A3–A8 — API buildout ✅ complete (74 operations)
 
 Order chosen so each SPA page can land right behind its API. Each PR:
 components → controller actions → jbuilder views → minitest DSL spec →
 regenerated schema → regenerated client.
 
-- [x] **A3** ✅ Auth + me + account. 32 operations described. Notes:
+- [x] **A3** ✅ Auth + me + account. 32 operations described, plus the two
+      added in B2 (below). Notes:
       - Login stores the session, so one endpoint serves both the SPA
         (cookie) and native clients (token).
       - `/me` exists because `/users/current` authorizes against the User
@@ -562,7 +563,8 @@ Vue page + components, vue-query hooks from the generated client, VeeValidate
 for the flow, then **the Rails route is repointed at the SPA and the old ERB
 views + Angular/jQuery/Coffee for that screen are deleted in the same PR**.
 
-- [ ] **B2** Login / signup / password reset / 2FA.
+- [ ] **B2** Login / signup / password reset / 2FA. Confirmation and unlock
+      are part of this surface too — see the API gap note below.
 - [ ] **B3** Customers list + form; Projects list, detail, form; Tasks.
 - [ ] **B4** Timesheet (day/week/month) — reuses `app/frontend/islands/timesheet/`
       SFCs, promoted to `frontend/pages/timesheet/`; deletes
@@ -577,6 +579,22 @@ views + Angular/jQuery/Coffee for that screen are deleted in the same PR**.
 
 Exit per PR: the ported screen has no server-rendered ERB left, Playwright
 covers it, and the corresponding legacy JS is gone from the repo.
+
+#### API gap found at the start of B2
+
+The auth surface is wider than "login / signup / password reset / 2FA". `User`
+enables `:confirmable` and `:lockable`, and both are live — `lock_strategy` is
+`:failed_attempts`, `unlock_strategy` is `:email`, `reconfirmable` is on — so
+`devise/confirmations` and `devise/unlocks` are real screens reached from links
+in email, not vestigial.
+
+A3 built neither endpoint, which made B2 impossible as written: repointing
+`/signin` and deleting the ERB auth views would strand every unlock and
+confirmation link already in an inbox, and a locked-out account has no other
+way back in. `POST/PUT /confirmations` and `POST/PUT /unlocks` close that gap.
+
+Worth checking the same way before each remaining B phase: the ERB screen a
+phase deletes may reach further than the phase's one-line description.
 
 ### Phase C — legacy removal (multi-PR, ~1 week)
 

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -245,6 +245,51 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/confirmations":
+    post:
+      summary: Resend the confirmation email
+      tags:
+      - Confirmations
+      operationId: requestConfirmation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ConfirmationRequestInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Message"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Confirm an email address using a token
+      tags:
+      - Confirmations
+      operationId: confirmEmail
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ConfirmationInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Message"
+        '400':
+          description: invalid or expired token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
   "/customers":
     get:
       summary: Customers list
@@ -2383,6 +2428,51 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/unlocks":
+    post:
+      summary: Resend the unlock email
+      tags:
+      - Unlocks
+      operationId: requestUnlock
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UnlockRequestInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Message"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Unlock an account using a token
+      tags:
+      - Unlocks
+      operationId: unlockAccount
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UnlockInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Message"
+        '400':
+          description: invalid or expired token
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
   "/users":
     get:
       summary: Users list
@@ -2717,6 +2807,25 @@ components:
       - count
       - message
       title: BulkResult
+    ConfirmationInput:
+      type: object
+      properties:
+        confirmation_token:
+          type: string
+          description: From the confirmation email.
+      additionalProperties: false
+      required:
+      - confirmation_token
+      title: ConfirmationInput
+    ConfirmationRequestInput:
+      type: object
+      properties:
+        email:
+          type: string
+      additionalProperties: false
+      required:
+      - email
+      title: ConfirmationRequestInput
     CurrentUser:
       type: object
       properties:
@@ -4246,6 +4355,25 @@ components:
       items:
         "$ref": "#/components/schemas/Timer"
       title: Timers
+    UnlockInput:
+      type: object
+      properties:
+        unlock_token:
+          type: string
+          description: From the unlock email.
+      additionalProperties: false
+      required:
+      - unlock_token
+      title: UnlockInput
+    UnlockRequestInput:
+      type: object
+      properties:
+        email:
+          type: string
+      additionalProperties: false
+      required:
+      - email
+      title: UnlockRequestInput
     User:
       type: object
       properties:

--- a/test/integration/api/v1/confirmations_test.rb
+++ b/test/integration/api/v1/confirmations_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+module Api
+  module V1
+    class ConfirmationsTest < ActionDispatch::IntegrationTest
+      include OpenapiRuby::Adapters::Minitest::DSL
+
+      openapi_schema :"v1/schema"
+
+      api_path "/confirmations" do
+        post("Resend the confirmation email") do
+          operationId "requestConfirmation"
+          tags "Confirmations"
+          consumes "application/json"
+          produces "application/json"
+
+          request_body required: true, content: {
+            "application/json" => {schema: ::V1::Schemas::Inputs::ConfirmationRequestInput}
+          }
+
+          response(200, "successful") do
+            schema ::V1::Schemas::Message
+          end
+        end
+
+        put("Confirm an email address using a token") do
+          operationId "confirmEmail"
+          tags "Confirmations"
+          consumes "application/json"
+          produces "application/json"
+
+          request_body required: true, content: {
+            "application/json" => {schema: ::V1::Schemas::Inputs::ConfirmationInput}
+          }
+
+          response(200, "successful") do
+            schema ::V1::Schemas::Message
+          end
+
+          response(400, "invalid or expired token") do
+            schema ::V1::Schemas::ValidationError
+          end
+        end
+      end
+
+      let(:unconfirmed) do
+        User.create!(
+          account: accounts(:enterprise),
+          name: "Reginald Barclay",
+          email: "barclay@star.fleet",
+          password: "enterprise",
+          password_confirmation: "enterprise"
+        )
+      end
+
+      describe "requesting a confirmation email" do
+        it "sends one for an unconfirmed address" do
+          unconfirmed
+
+          assert_difference "ActionMailer::Base.deliveries.size", 1 do
+            assert_api_response :post, 200, body: {email: unconfirmed.email}
+          end
+        end
+
+        # config.paranoid is on: an unauthenticated caller must not be able to
+        # tell a registered address from an unregistered one.
+        it "reports the same result for an unknown address" do
+          assert_api_response :post, 200, body: {email: "nobody@star.fleet"} do
+            refute_includes parsed_body["message"], "Translation missing"
+          end
+        end
+      end
+
+      describe "confirming with a token" do
+        it "confirms the address" do
+          raw = unconfirmed.confirmation_token
+
+          assert_api_response :put, 200, body: {confirmation_token: raw} do
+            refute_includes parsed_body["message"], "Translation missing"
+          end
+
+          assert unconfirmed.reload.confirmed?
+        end
+
+        it "refuses an invalid token" do
+          unconfirmed
+
+          assert_api_response :put, 400, body: {confirmation_token: "not-a-real-token"} do
+            assert_equal "validation_error.confirmation.update", parsed_body["code"]
+            refute_includes parsed_body["message"], "Translation missing"
+          end
+
+          refute unconfirmed.reload.confirmed?
+        end
+      end
+    end
+  end
+end

--- a/test/integration/api/v1/unlocks_test.rb
+++ b/test/integration/api/v1/unlocks_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+module Api
+  module V1
+    class UnlocksTest < ActionDispatch::IntegrationTest
+      include OpenapiRuby::Adapters::Minitest::DSL
+
+      openapi_schema :"v1/schema"
+
+      api_path "/unlocks" do
+        post("Resend the unlock email") do
+          operationId "requestUnlock"
+          tags "Unlocks"
+          consumes "application/json"
+          produces "application/json"
+
+          request_body required: true, content: {
+            "application/json" => {schema: ::V1::Schemas::Inputs::UnlockRequestInput}
+          }
+
+          response(200, "successful") do
+            schema ::V1::Schemas::Message
+          end
+        end
+
+        put("Unlock an account using a token") do
+          operationId "unlockAccount"
+          tags "Unlocks"
+          consumes "application/json"
+          produces "application/json"
+
+          request_body required: true, content: {
+            "application/json" => {schema: ::V1::Schemas::Inputs::UnlockInput}
+          }
+
+          response(200, "successful") do
+            schema ::V1::Schemas::Message
+          end
+
+          response(400, "invalid or expired token") do
+            schema ::V1::Schemas::ValidationError
+          end
+        end
+      end
+
+      let(:data) { users :data }
+
+      describe "requesting an unlock email" do
+        it "sends one for a locked account" do
+          data.lock_access!
+
+          assert_difference "ActionMailer::Base.deliveries.size", 1 do
+            assert_api_response :post, 200, body: {email: data.email}
+          end
+        end
+
+        # config.paranoid is on: an unauthenticated caller must not be able to
+        # tell a registered address from an unregistered one.
+        it "reports the same result for an unknown address" do
+          assert_api_response :post, 200, body: {email: "nobody@star.fleet"} do
+            refute_includes parsed_body["message"], "Translation missing"
+          end
+        end
+      end
+
+      describe "unlocking with a token" do
+        # Only the digest is stored, so the raw token has to come from the call
+        # that generates it — `send_unlock_instructions` returns it.
+        it "unlocks the account" do
+          data.lock_access!(send_instructions: false)
+          raw = data.send_unlock_instructions
+
+          assert data.reload.access_locked?
+
+          assert_api_response :put, 200, body: {unlock_token: raw} do
+            refute_includes parsed_body["message"], "Translation missing"
+          end
+
+          refute data.reload.access_locked?
+        end
+
+        it "refuses an invalid token" do
+          data.lock_access!(send_instructions: false)
+
+          assert_api_response :put, 400, body: {unlock_token: "not-a-real-token"} do
+            assert_equal "validation_error.unlock.update", parsed_body["code"]
+            refute_includes parsed_body["message"], "Translation missing"
+          end
+
+          assert data.reload.access_locked?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes an A3 gap found while scoping B2. **Blocks B2** — it cannot do what it is defined as doing without these.

### The gap

`User` enables `:confirmable` and `:lockable`, and both are live:

```ruby
config.lock_strategy   = :failed_attempts
config.unlock_strategy = :email
config.reconfirmable   = true
```

So `devise/confirmations` and `devise/unlocks` are real screens, reached from links in email — not vestigial views. A3 described 32 auth operations but built neither endpoint.

B2 is defined as "the Rails route is repointed at the SPA and the old ERB views are deleted in the same PR". Doing that today would strand every unlock and confirmation link, **including ones already sitting in inboxes**, with no API for the SPA to serve them from. A locked-out account has no other way back in.

### What this adds

| | |
|---|---|
| `POST /confirmations` | resend the confirmation email |
| `PUT /confirmations` | confirm an address by token |
| `POST /unlocks` | resend the unlock email |
| `PUT /unlocks` | unlock an account by token |

Both mirror `PasswordsController`: paranoid on the request side (`config.paranoid` is on, so whether an address has an account must not be probeable), and a `ValidationError` on a bad token.

The `validation_error.confirmation.update` and `validation_error.unlock.update` keys did not exist, so both error paths would have rendered `Translation missing` — the same gap A3 had to close for task, timer, user, account and password. Tests assert a real translation on every message.

### Verification

303 runs / 1008 assertions, redocly valid, standardrb clean, `vue-tsc` clean, 44 vitest. Schema additive only: 74 operations, up from 70. One `api_path` per file holds at 46/46.

🤖