### PR TITLE
feat(frontend): add the two-factor settings screen

### DIFF
--- a/app/frontend/App.vue
+++ b/app/frontend/App.vue
@@ -26,6 +26,9 @@ async function signOut(): Promise<void> {
         <RouterLink :to="{ name: 'customers' }">
           {{ t("nav.customers") }}
         </RouterLink>
+        <RouterLink :to="{ name: 'two-factor' }" data-test="nav-two-factor">
+          {{ t("nav.security") }}
+        </RouterLink>
 
         <span v-if="currentUser.user" class="ml-auto text-sm text-gray-500" data-test="account">
           {{ currentUser.user.email }}

--- a/app/frontend/pages/settings/TwoFactorPage.vue
+++ b/app/frontend/pages/settings/TwoFactorPage.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue"
+import { useI18n } from "vue-i18n"
+import {
+  createOtpEnrollment,
+  enableOtp,
+  disableOtp,
+  regenerateOtpBackupCodes,
+} from "@/services/api/services/otp/otp"
+import { useCurrentUserStore } from "@/stores/currentUser"
+
+const { t } = useI18n()
+const currentUser = useCurrentUserStore()
+
+const enabled = ref(currentUser.user?.otpRequired === true)
+const provisioningUri = ref<string | undefined>()
+const codes = ref<string[] | undefined>()
+const otpToken = ref("")
+const failed = ref(false)
+const busy = ref(false)
+
+// The QR code is an SVG served straight from the API rather than JSON, so it
+// is rendered by URL instead of through the generated client.
+const qrcodeUrl = "/api/v1/me/otp/qrcode"
+
+async function startEnrollment(): Promise<void> {
+  const enrollment = await createOtpEnrollment()
+  provisioningUri.value = enrollment.provisioningUri
+}
+
+onMounted(async () => {
+  if (!enabled.value) await startEnrollment()
+})
+
+async function enable(): Promise<void> {
+  failed.value = false
+  busy.value = true
+
+  try {
+    const result = await enableOtp({ otp_attempt: otpToken.value })
+    codes.value = result.backupCodes
+    enabled.value = true
+    otpToken.value = ""
+    await currentUser.refresh()
+  } catch {
+    failed.value = true
+  } finally {
+    busy.value = false
+  }
+}
+
+async function disable(): Promise<void> {
+  failed.value = false
+  busy.value = true
+
+  try {
+    await disableOtp({ otp_attempt: otpToken.value })
+    enabled.value = false
+    codes.value = undefined
+    otpToken.value = ""
+    await currentUser.refresh()
+    await startEnrollment()
+  } catch {
+    failed.value = true
+  } finally {
+    busy.value = false
+  }
+}
+
+async function regenerate(): Promise<void> {
+  failed.value = false
+  busy.value = true
+
+  try {
+    const result = await regenerateOtpBackupCodes()
+    codes.value = result.backupCodes
+  } catch {
+    failed.value = true
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="px-4 py-6">
+    <h1 class="mb-4 text-[24px] font-medium" data-test="two-factor-title">
+      {{ t("twoFactor.title") }}
+    </h1>
+
+    <p v-if="failed" data-test="two-factor-failed" class="mb-4 text-[14px] text-[#a94442]">
+      {{ t("twoFactor.failed") }}
+    </p>
+
+    <!-- Shown once, right after enabling or regenerating: the API returns the
+         codes in the clear and never again. -->
+    <div v-if="codes" class="mb-6" data-test="backup-codes">
+      <p class="mb-2 text-[14px]">{{ t("twoFactor.backupExplain") }}</p>
+      <pre class="max-w-sm rounded border border-field-border bg-[#f5f5f5] p-3 text-[13px]">{{ codes.join("\n") }}</pre>
+    </div>
+
+    <template v-if="enabled">
+      <p class="mb-4 text-[14px]" data-test="two-factor-enabled">{{ t("twoFactor.disableExplain") }}</p>
+
+      <button
+        type="button"
+        data-test="regenerate-codes"
+        :disabled="busy"
+        class="mb-6 rounded border border-[#eea236] bg-[#f0ad4e] px-4 py-2 text-[14px] text-white disabled:opacity-65"
+        @click="regenerate"
+      >
+        {{ t("twoFactor.backupCodes") }}
+      </button>
+
+      <form class="max-w-sm" @submit.prevent="disable">
+        <input
+          v-model="otpToken"
+          type="text"
+          inputmode="numeric"
+          autocomplete="one-time-code"
+          :placeholder="t('twoFactor.otpToken')"
+          data-test="otp-token"
+          class="mb-3 block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+        />
+        <button
+          type="submit"
+          data-test="disable-otp"
+          :disabled="busy"
+          class="rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] text-white disabled:opacity-65"
+        >
+          {{ t("twoFactor.disable") }}
+        </button>
+      </form>
+    </template>
+
+    <template v-else>
+      <p class="mb-4 text-[14px]">{{ t("twoFactor.enableExplain") }}</p>
+
+      <img :src="qrcodeUrl" alt="" class="mb-3 h-48 w-48" data-test="otp-qrcode" />
+
+      <pre
+        v-if="provisioningUri"
+        class="mb-4 max-w-lg overflow-x-auto rounded border border-field-border bg-[#f5f5f5] p-3 text-[12px]"
+        data-test="provisioning-uri"
+        >{{ provisioningUri }}</pre
+      >
+
+      <form class="max-w-sm" @submit.prevent="enable">
+        <input
+          v-model="otpToken"
+          type="text"
+          inputmode="numeric"
+          autocomplete="one-time-code"
+          :placeholder="t('twoFactor.otpToken')"
+          data-test="otp-token"
+          class="mb-3 block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+        />
+        <button
+          type="submit"
+          data-test="enable-otp"
+          :disabled="busy"
+          class="rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] text-white disabled:opacity-65"
+        >
+          {{ t("twoFactor.enable") }}
+        </button>
+      </form>
+    </template>
+  </div>
+</template>

--- a/app/frontend/plugins/router.ts
+++ b/app/frontend/plugins/router.ts
@@ -33,6 +33,12 @@ const routes: RouteRecordRaw[] = [
     meta: { requiresAuth: true },
   },
   {
+    path: "/settings/two-factor",
+    name: "two-factor",
+    component: () => import("@/pages/settings/TwoFactorPage.vue"),
+    meta: { requiresAuth: true },
+  },
+  {
     path: "/customers",
     name: "customers",
     component: () => import("@/pages/customers/CustomersList.vue"),

--- a/app/frontend/translations/de.ts
+++ b/app/frontend/translations/de.ts
@@ -3,6 +3,7 @@ export default {
   nav: {
     dashboard: "Übersicht",
     customers: "Kunden",
+    security: "Sicherheit",
     signOut: "Abmelden",
   },
   login: {
@@ -37,6 +38,18 @@ export default {
     haveAccount: "Bereits registriert?",
     backToLogin: "Zur Anmeldung",
     failed: "Registrierung fehlgeschlagen.",
+  },
+  twoFactor: {
+    title: "Zwei-Faktor-Autorisierung",
+    enableExplain: "Scanen Sie diesen QRCode und geben Sie einen der generierten Tokens ein.",
+    disableExplain:
+      "Wenn Sie die Zwei-Faktor-Autorisierung wieder deaktivieren wollen, geben Sie einen der generierten Tokens ein.",
+    backupExplain: "Speichern Sie diese Backup Codes an einem sicherem Ort.",
+    backupCodes: "Backup Codes generieren",
+    otpToken: "Einmal-Token",
+    enable: "Aktivieren",
+    disable: "Deaktivieren",
+    failed: "Der Token wurde nicht akzeptiert.",
   },
   dashboard: {
     title: "Übersicht",

--- a/app/frontend/translations/en.ts
+++ b/app/frontend/translations/en.ts
@@ -3,6 +3,7 @@ export default {
   nav: {
     dashboard: "Dashboard",
     customers: "Customers",
+    security: "Security",
     signOut: "Sign out",
   },
   login: {
@@ -37,6 +38,17 @@ export default {
     haveAccount: "Already registered?",
     backToLogin: "Sign in",
     failed: "Registration failed.",
+  },
+  twoFactor: {
+    title: "Two-factor authentication",
+    enableExplain: "Scan this QR code and enter one of the generated tokens.",
+    disableExplain: "To switch two-factor authentication off, enter one of the generated tokens.",
+    backupExplain: "Keep these backup codes somewhere safe.",
+    backupCodes: "Generate backup codes",
+    otpToken: "One-time token",
+    enable: "Enable",
+    disable: "Disable",
+    failed: "That token was not accepted.",
   },
   dashboard: {
     title: "Dashboard",

--- a/test/e2e/TwoFactor.spec.ts
+++ b/test/e2e/TwoFactor.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "./support/commands"
+import { app, appScenario } from "./support/on-rails"
+
+// The 2FA screen the plan calls for in B2. Enabling for real needs a valid TOTP
+// code, which a browser test cannot produce — so this covers enrollment and the
+// rejection path, and leaves code generation to the API's own tests.
+test.describe("Two-factor settings", () => {
+  test.beforeEach(async ({ page }) => {
+    await app("clean")
+    await appScenario("signed_out_user")
+
+    await page.goto("/app/login")
+    await page.getByTestId("email").fill("will@star.fleet")
+    await page.getByTestId("password").fill("enterprise")
+    await page.getByTestId("submit").click()
+    await expect(page.getByTestId("dashboard-greeting")).toBeVisible()
+  })
+
+  test("offers enrollment with a qr code and a provisioning uri", async ({ page }) => {
+    await page.getByTestId("nav-two-factor").click()
+
+    await expect(page).toHaveURL(/\/app\/settings\/two-factor$/)
+    await expect(page.getByTestId("two-factor-title")).toBeVisible()
+
+    // POST /me/otp on mount generates the secret the URI encodes.
+    await expect(page.getByTestId("provisioning-uri")).toContainText("otpauth://")
+    await expect(page.getByTestId("otp-qrcode")).toBeVisible()
+  })
+
+  test("serves the qr code as an svg", async ({ page }) => {
+    await page.goto("/app/settings/two-factor")
+    await expect(page.getByTestId("provisioning-uri")).toBeVisible()
+
+    const response = await page.request.get("/api/v1/me/otp/qrcode")
+
+    expect(response.status()).toBe(200)
+    expect(response.headers()["content-type"]).toContain("image/svg+xml")
+  })
+
+  test("rejects a token the authenticator did not produce", async ({ page }) => {
+    await page.goto("/app/settings/two-factor")
+    await expect(page.getByTestId("provisioning-uri")).toBeVisible()
+
+    await page.getByTestId("otp-token").fill("000000")
+    await page.getByTestId("enable-otp").click()
+
+    await expect(page.getByTestId("two-factor-failed")).toBeVisible()
+    // Still on the enrollment side, not the enabled one.
+    await expect(page.getByTestId("enable-otp")).toBeVisible()
+  })
+})


### PR DESCRIPTION
Stacked on #960, which is stacked on #959. Review those first.

The 2FA half of B2, built on the `/me/otp` endpoints A3 already shipped — enrollment, enable, disable, and backup-code regeneration. Copy is lifted from `app/views/current_user/otp.html.erb`, the screen it mirrors.

### Notes

- **The QR code is rendered by URL, not through the generated client.** `GET /me/otp/qrcode` serves `image/svg+xml`, not JSON, so it goes in an `<img src>`.
- **Backup codes are shown once**, right after enabling or regenerating. The API returns them in the clear and never again.
- **Enabling for real needs a valid TOTP code**, which a browser test cannot produce. The spec covers enrollment, the SVG content type, and the rejection path; generating codes stays covered by the API tests.

### Signup is deliberately absent from B2

`POST /api/v1/registrations` cannot create a real account:

```
plan=basic  valid=false  errors=["Stripe token …", "Stripe email …"]
plan=free   valid=true   errors=[]
```

`Account` requires `stripe_token`/`stripe_email` on create for a paid plan, `on_plan?` is a string comparison rather than a `Plan` lookup, and **all three real plans are paid** — there is no `free` plan record. The existing contract test passes only because it posts `plan: "free"`, so it is green while proving nothing about signup a user could perform. The ERB form works because it loads Stripe Checkout.

Signup therefore stays server-rendered until that is dealt with properly.

### Unrelated pre-existing failure

`Timesheet.spec.ts › removes a row only after the confirm is accepted` fails locally — the seeded `E2E Task` row is never found. It fails identically on unmodified `main` (`99a7ca49`), so it is not from this work. It passed in CI on #960, which suggests something local to this checkout rather than the spec itself.

### Verification

308 runs / 1030 assertions, 44 vitest, `vue-tsc` clean, standardrb clean on 374 files. New spec: 3 passing.

🤖