### PR TITLE
feat(frontend): add the confirmation and unlock screens

### DIFF
--- a/app/frontend/pages/sessions/ConfirmationPage.vue
+++ b/app/frontend/pages/sessions/ConfirmationPage.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue"
+import { useRoute, RouterLink } from "vue-router"
+import { useI18n } from "vue-i18n"
+import { useForm } from "vee-validate"
+import { toTypedSchema } from "@vee-validate/zod"
+import * as z from "zod"
+import {
+  confirmEmail,
+  requestConfirmation,
+} from "@/services/api/services/confirmations/confirmations"
+
+const { t } = useI18n()
+const route = useRoute()
+
+const message = ref<string | undefined>()
+const failed = ref(false)
+const redeeming = ref(false)
+
+// Devise mails a link carrying the token as a query param. Arriving without
+// one means the visitor wants a fresh email instead.
+const token = String(route.query.confirmation_token ?? "")
+
+onMounted(async () => {
+  if (!token) return
+
+  redeeming.value = true
+
+  try {
+    const result = await confirmEmail({ confirmation_token: token })
+    message.value = result.message
+  } catch {
+    failed.value = true
+  } finally {
+    redeeming.value = false
+  }
+})
+
+const schema = toTypedSchema(
+  z.object({
+    email: z
+      .string({ message: t("validation.emailRequired") })
+      .min(1, t("validation.emailRequired"))
+      .email(t("validation.emailInvalid")),
+  }),
+)
+
+const { handleSubmit, errors, defineField, isSubmitting } = useForm({ validationSchema: schema })
+const [email, emailAttrs] = defineField("email")
+
+const onSubmit = handleSubmit(async (values) => {
+  failed.value = false
+
+  try {
+    const result = await requestConfirmation({ email: values.email })
+    message.value = result.message
+  } catch {
+    failed.value = true
+  }
+})
+</script>
+
+<template>
+  <div class="mx-auto mt-[12%] w-full max-w-[300px] px-3 md:px-0">
+    <h1 class="mb-5 text-center font-brand text-[30px] font-medium leading-tight">
+      <a href="/" class="text-brand no-underline hover:no-underline">{{ t("brand") }}</a>
+    </h1>
+
+    <p v-if="redeeming" data-test="confirming" class="mb-[15px] text-center text-[14px]">
+      {{ t("confirmation.confirming") }}
+    </p>
+
+    <p v-else-if="message" data-test="confirmation-message" class="mb-[15px] text-[14px]">
+      {{ message }}
+    </p>
+
+    <template v-else>
+      <p v-if="failed" data-test="confirmation-failed" class="mb-[10px] text-[14px] text-[#a94442]">
+        {{ t("confirmation.failed") }}
+      </p>
+
+      <form novalidate @submit="onSubmit">
+        <p class="mb-[15px] text-center text-[14px]">{{ t("confirmation.resendPrompt") }}</p>
+
+        <div class="mb-[15px]">
+          <input
+            v-model="email"
+            v-bind="emailAttrs"
+            type="email"
+            autocomplete="username"
+            autofocus
+            :placeholder="t('login.email')"
+            data-test="email"
+            class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          />
+          <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-[#a94442]">
+            {{ errors.email }}
+          </p>
+        </div>
+
+        <button
+          type="submit"
+          data-test="submit"
+          :disabled="isSubmitting"
+          class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-[#3276b1] disabled:opacity-65"
+        >
+          {{ isSubmitting ? t("login.submitting") : t("confirmation.resend") }}
+        </button>
+      </form>
+    </template>
+
+    <div class="text-center">
+      <RouterLink
+        :to="{ name: 'login' }"
+        data-test="back-to-login"
+        class="inline-block px-3 py-[6px] text-[14px] text-brand hover:underline"
+      >
+        {{ t("passwordReset.backToLogin") }}
+      </RouterLink>
+    </div>
+  </div>
+</template>

--- a/app/frontend/pages/sessions/UnlockPage.vue
+++ b/app/frontend/pages/sessions/UnlockPage.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue"
+import { useRoute, RouterLink } from "vue-router"
+import { useI18n } from "vue-i18n"
+import { useForm } from "vee-validate"
+import { toTypedSchema } from "@vee-validate/zod"
+import * as z from "zod"
+import { unlockAccount, requestUnlock } from "@/services/api/services/unlocks/unlocks"
+
+const { t } = useI18n()
+const route = useRoute()
+
+const message = ref<string | undefined>()
+const failed = ref(false)
+const redeeming = ref(false)
+
+// Locking is by failed attempts and unlocking is by email, so this link is the
+// only way back into a locked account.
+const token = String(route.query.unlock_token ?? "")
+
+onMounted(async () => {
+  if (!token) return
+
+  redeeming.value = true
+
+  try {
+    const result = await unlockAccount({ unlock_token: token })
+    message.value = result.message
+  } catch {
+    failed.value = true
+  } finally {
+    redeeming.value = false
+  }
+})
+
+const schema = toTypedSchema(
+  z.object({
+    email: z
+      .string({ message: t("validation.emailRequired") })
+      .min(1, t("validation.emailRequired"))
+      .email(t("validation.emailInvalid")),
+  }),
+)
+
+const { handleSubmit, errors, defineField, isSubmitting } = useForm({ validationSchema: schema })
+const [email, emailAttrs] = defineField("email")
+
+const onSubmit = handleSubmit(async (values) => {
+  failed.value = false
+
+  try {
+    const result = await requestUnlock({ email: values.email })
+    message.value = result.message
+  } catch {
+    failed.value = true
+  }
+})
+</script>
+
+<template>
+  <div class="mx-auto mt-[12%] w-full max-w-[300px] px-3 md:px-0">
+    <h1 class="mb-5 text-center font-brand text-[30px] font-medium leading-tight">
+      <a href="/" class="text-brand no-underline hover:no-underline">{{ t("brand") }}</a>
+    </h1>
+
+    <p v-if="redeeming" data-test="unlocking" class="mb-[15px] text-center text-[14px]">
+      {{ t("unlock.unlocking") }}
+    </p>
+
+    <p v-else-if="message" data-test="unlock-message" class="mb-[15px] text-[14px]">
+      {{ message }}
+    </p>
+
+    <template v-else>
+      <p v-if="failed" data-test="unlock-failed" class="mb-[10px] text-[14px] text-[#a94442]">
+        {{ t("unlock.failed") }}
+      </p>
+
+      <form novalidate @submit="onSubmit">
+        <p class="mb-[15px] text-center text-[14px]">{{ t("unlock.resendPrompt") }}</p>
+
+        <div class="mb-[15px]">
+          <input
+            v-model="email"
+            v-bind="emailAttrs"
+            type="email"
+            autocomplete="username"
+            autofocus
+            :placeholder="t('login.email')"
+            data-test="email"
+            class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          />
+          <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-[#a94442]">
+            {{ errors.email }}
+          </p>
+        </div>
+
+        <button
+          type="submit"
+          data-test="submit"
+          :disabled="isSubmitting"
+          class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-[#3276b1] disabled:opacity-65"
+        >
+          {{ isSubmitting ? t("login.submitting") : t("unlock.resend") }}
+        </button>
+      </form>
+    </template>
+
+    <div class="text-center">
+      <RouterLink
+        :to="{ name: 'login' }"
+        data-test="back-to-login"
+        class="inline-block px-3 py-[6px] text-[14px] text-brand hover:underline"
+      >
+        {{ t("passwordReset.backToLogin") }}
+      </RouterLink>
+    </div>
+  </div>
+</template>

--- a/app/frontend/plugins/router.ts
+++ b/app/frontend/plugins/router.ts
@@ -33,6 +33,19 @@ const routes: RouteRecordRaw[] = [
     meta: { requiresAuth: true },
   },
   {
+    // Devise mails a link carrying confirmation_token as a query param.
+    path: "/confirmation",
+    name: "confirmation",
+    component: () => import("@/pages/sessions/ConfirmationPage.vue"),
+    meta: { requiresAuth: false },
+  },
+  {
+    path: "/unlock",
+    name: "unlock",
+    component: () => import("@/pages/sessions/UnlockPage.vue"),
+    meta: { requiresAuth: false },
+  },
+  {
     path: "/settings/two-factor",
     name: "two-factor",
     component: () => import("@/pages/settings/TwoFactorPage.vue"),

--- a/app/frontend/services/axiosClient.spec.ts
+++ b/app/frontend/services/axiosClient.spec.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import type { AxiosAdapter, InternalAxiosRequestConfig } from "axios"
-import { AXIOS_INSTANCE, axiosClient, onUnauthorized } from "@/services/axiosClient"
+import {
+  AXIOS_INSTANCE,
+  axiosClient,
+  onUnauthorized,
+  withoutUnauthorizedRedirect,
+} from "@/services/axiosClient"
 
 function captureRequest(): { config: () => InternalAxiosRequestConfig | undefined } {
   let seen: InternalAxiosRequestConfig | undefined
@@ -84,6 +89,52 @@ describe("axiosClient", () => {
       )) as AxiosAdapter
 
     await expect(axiosClient({ url: "/me", method: "GET" })).rejects.toThrow()
+
+    expect(notified).toBe(1)
+  })
+
+  // Asking "is anyone signed in?" answers 401 for a signed-out visitor. Firing
+  // the handler for that bounced every public route — confirmation, unlock,
+  // password reset — to the login screen on first load.
+  it("stays quiet for a 401 inside withoutUnauthorizedRedirect", async () => {
+    let notified = 0
+    onUnauthorized(() => {
+      notified += 1
+    })
+
+    AXIOS_INSTANCE.defaults.adapter = (() =>
+      Promise.reject(
+        Object.assign(new Error("unauthorized"), {
+          isAxiosError: true,
+          response: { status: 401, data: {}, statusText: "", headers: {}, config: {} },
+        }),
+      )) as AxiosAdapter
+
+    await expect(
+      withoutUnauthorizedRedirect(() => axiosClient({ url: "/me", method: "GET" })),
+    ).rejects.toThrow()
+
+    expect(notified).toBe(0)
+  })
+
+  it("resumes notifying once the suppressed call finishes", async () => {
+    let notified = 0
+    onUnauthorized(() => {
+      notified += 1
+    })
+
+    AXIOS_INSTANCE.defaults.adapter = (() =>
+      Promise.reject(
+        Object.assign(new Error("unauthorized"), {
+          isAxiosError: true,
+          response: { status: 401, data: {}, statusText: "", headers: {}, config: {} },
+        }),
+      )) as AxiosAdapter
+
+    await expect(
+      withoutUnauthorizedRedirect(() => axiosClient({ url: "/me", method: "GET" })),
+    ).rejects.toThrow()
+    await expect(axiosClient({ url: "/customers", method: "GET" })).rejects.toThrow()
 
     expect(notified).toBe(1)
   })

--- a/app/frontend/services/axiosClient.ts
+++ b/app/frontend/services/axiosClient.ts
@@ -34,10 +34,24 @@ export function onUnauthorized(handler: UnauthorizedHandler): void {
   unauthorizedHandler = handler;
 }
 
+let suppressDepth = 0;
+
+// Asking "is anyone signed in?" answers 401 for a signed-out visitor, which is
+// the expected answer rather than a session that just expired. Without this,
+// loading any public route — confirmation, unlock, password reset — would fire
+// the handler and bounce the visitor to the login screen.
+export function withoutUnauthorizedRedirect<T>(fn: () => Promise<T>): Promise<T> {
+  suppressDepth += 1;
+
+  return fn().finally(() => {
+    suppressDepth -= 1;
+  });
+}
+
 AXIOS_INSTANCE.interceptors.response.use(
   (response) => response,
   (error: AxiosError) => {
-    if (error.response?.status === 401) {
+    if (error.response?.status === 401 && suppressDepth === 0) {
       unauthorizedHandler?.();
     }
 

--- a/app/frontend/stores/currentUser.ts
+++ b/app/frontend/stores/currentUser.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { ref, computed } from "vue";
 import { me } from "@/services/api/services/me/me";
 import { destroySession } from "@/services/api/services/sessions/sessions";
+import { withoutUnauthorizedRedirect } from "@/services/axiosClient";
 import type { CurrentUser } from "@/services/api/models";
 
 export const useCurrentUserStore = defineStore(
@@ -20,7 +21,7 @@ export const useCurrentUserStore = defineStore(
       if (resolved.value) return user.value;
       if (inFlight) return inFlight;
 
-      inFlight = me()
+      inFlight = withoutUnauthorizedRedirect(() => me())
         .then((current) => {
           user.value = current;
           return current;

--- a/app/frontend/translations/de.ts
+++ b/app/frontend/translations/de.ts
@@ -39,6 +39,18 @@ export default {
     backToLogin: "Zur Anmeldung",
     failed: "Registrierung fehlgeschlagen.",
   },
+  confirmation: {
+    confirming: "E-Mail-Adresse wird bestätigt...",
+    resendPrompt: "Bestätigungs-E-Mail erneut senden",
+    resend: "E-Mail senden",
+    failed: "Der Bestätigungslink ist ungültig oder abgelaufen.",
+  },
+  unlock: {
+    unlocking: "Konto wird entsperrt...",
+    resendPrompt: "Entsperr-E-Mail erneut senden",
+    resend: "E-Mail senden",
+    failed: "Der Entsperrlink ist ungültig oder abgelaufen.",
+  },
   twoFactor: {
     title: "Zwei-Faktor-Autorisierung",
     enableExplain: "Scanen Sie diesen QRCode und geben Sie einen der generierten Tokens ein.",

--- a/app/frontend/translations/en.ts
+++ b/app/frontend/translations/en.ts
@@ -39,6 +39,18 @@ export default {
     backToLogin: "Sign in",
     failed: "Registration failed.",
   },
+  confirmation: {
+    confirming: "Confirming your email address...",
+    resendPrompt: "Resend the confirmation email",
+    resend: "Send email",
+    failed: "That confirmation link is invalid or has expired.",
+  },
+  unlock: {
+    unlocking: "Unlocking your account...",
+    resendPrompt: "Resend the unlock email",
+    resend: "Send email",
+    failed: "That unlock link is invalid or has expired.",
+  },
   twoFactor: {
     title: "Two-factor authentication",
     enableExplain: "Scan this QR code and enter one of the generated tokens.",

--- a/test/e2e/ConfirmationUnlock.spec.ts
+++ b/test/e2e/ConfirmationUnlock.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "./support/commands"
+import { app, appScenario, appEval } from "./support/on-rails"
+
+// The two screens B2 cannot delete the ERB auth views without: both are reached
+// from a link in an email, and a locked account has no other way back in.
+test.describe("Confirmation and unlock", () => {
+  test.beforeEach(async () => {
+    await app("clean")
+    await appScenario("signed_out_user")
+  })
+
+  test("confirms an address from the emailed token", async ({ page }) => {
+    // Only the digest is stored, so the raw token has to come from the call
+    // that generates it.
+    const token = (await appEval(`
+      user = User.new(
+        account: Account.find_by(name: "Enterprise"),
+        name: "Reginald Barclay",
+        email: "barclay@star.fleet",
+        password: "enterprise",
+        password_confirmation: "enterprise"
+      )
+      user.save(validate: false)
+      user.confirmation_token
+    `)) as string
+
+    await page.goto(`/app/confirmation?confirmation_token=${token}`)
+
+    await expect(page.getByTestId("confirmation-message")).toBeVisible()
+
+    const confirmed = await appEval(`User.find_by(email: "barclay@star.fleet").confirmed?`)
+    expect(confirmed).toBe(true)
+  })
+
+  test("rejects a confirmation token that was never issued", async ({ page }) => {
+    await page.goto("/app/confirmation?confirmation_token=not-a-real-token")
+
+    await expect(page.getByTestId("confirmation-failed")).toBeVisible()
+    // Falls back to the resend form rather than dead-ending.
+    await expect(page.getByTestId("email")).toBeVisible()
+  })
+
+  test("unlocks an account from the emailed token", async ({ page }) => {
+    const token = (await appEval(`
+      user = User.find_by(email: "will@star.fleet")
+      user.lock_access!(send_instructions: false)
+      user.send_unlock_instructions
+    `)) as string
+
+    await page.goto(`/app/unlock?unlock_token=${token}`)
+
+    await expect(page.getByTestId("unlock-message")).toBeVisible()
+
+    const locked = await appEval(`User.find_by(email: "will@star.fleet").access_locked?`)
+    expect(locked).toBe(false)
+  })
+
+  test("offers a fresh unlock email when the link has expired", async ({ page }) => {
+    await page.goto("/app/unlock?unlock_token=stale")
+
+    await expect(page.getByTestId("unlock-failed")).toBeVisible()
+
+    await page.getByTestId("email").fill("will@star.fleet")
+    await page.getByTestId("submit").click()
+
+    // Paranoid endpoint: the same message either way, so assert it responded
+    // rather than what it revealed.
+    await expect(page.getByTestId("unlock-message")).toBeVisible()
+  })
+})

--- a/test/e2e/Spa.spec.ts
+++ b/test/e2e/Spa.spec.ts
@@ -84,6 +84,17 @@ test.describe("SPA shell", () => {
     expect(cookies.some((c) => c.name.startsWith("RECKONING"))).toBe(true)
   })
 
+  // Loading a public route directly asks /me, which answers 401 for a
+  // signed-out visitor. That used to trip the global unauthorized handler and
+  // bounce straight back to login — only reachable on a fresh load, so
+  // clicking through from the login page never caught it.
+  test("opens a public route directly without bouncing to login", async ({ page }) => {
+    await page.goto("/app/password/new")
+
+    await expect(page).toHaveURL(/\/app\/password\/new$/)
+    await expect(page.getByTestId("email")).toBeVisible()
+  })
+
   test("validates the form before calling the api", async ({ page }) => {
     await page.goto("/app/login")
 


### PR DESCRIPTION
Stacked on #961 → #960 → #959. Review those first.

The two screens B2 cannot delete the ERB auth views without: both are reached from a link in an email, and with `lock_strategy = :failed_attempts` / `unlock_strategy = :email` a locked account has **no other way back in**. Built on the endpoints #959 added.

Arriving without a token — expired link, or someone who never got the mail — falls back to requesting a fresh one rather than dead-ending.

## Writing these found a real bug

Both screens redirected straight to `/app/login` on load. It was not the route guard:

> the URL was `/app/login` with **no** `?redirect=` — the guard always adds one

The route guard asks `/me` on every navigation. For a signed-out visitor that answers **401** — the expected answer, not an expired session — and the global unauthorized handler fired anyway and replaced the route with login.

So **every public SPA route was broken on direct load**, including password reset from #960. It only survived review because the existing spec *clicks through* from the login page, which reuses the store's already-resolved answer and never issues a second `/me`. A fresh load was the one path nothing covered.

`withoutUnauthorizedRedirect` scopes the suppression to the identity check rather than disabling the handler, so a session that genuinely expires mid-use still ends at login. Covered at both levels: two unit tests (suppressed, and resumes afterwards) and an e2e test that opens `/app/password/new` cold.

## Verification

308 runs / 1030 assertions, 46 vitest, 14 SPA Playwright tests, `vue-tsc` clean, standardrb clean on 374 files.

The confirmation/unlock specs drive real Devise tokens through `appEval`, since only the digest is stored and the raw token has to come from the call that generates it.

## Still outstanding for B2

- **Signup** stays server-rendered — `POST /registrations` cannot create a real account (see #961).
- **The emails still link to the ERB routes.** Repointing them is part of the deletion step, which remains gated on parity coverage for otp-required and lockout.

🤖