### PR TITLE
fix(api): match the session endpoint's auth behavior to /signin

### DIFF
--- a/app/api_components/v1/schemas/inputs/session_input.rb
+++ b/app/api_components/v1/schemas/inputs/session_input.rb
@@ -11,7 +11,7 @@ module V1
           properties: {
             email: {type: :string},
             password: {type: :string},
-            otp_token: {type: :string, description: "Required when the account has 2FA enabled."},
+            otp_token: {type: :string, description: "Required when the account has 2FA enabled. Takes a TOTP code or one of the account's backup codes."},
             remember_me: {type: :boolean, description: "Issue a persistent cookie. Ignored by token clients."},
             description: {type: :string, description: "Labels the token in the account's token list."},
             expires: {type: :string, format: "date-time"}

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -75,15 +75,21 @@ module Api
       # account holding the right password.
       private def valid_credentials?(resource)
         resource.valid_for_authentication? do
-          resource.valid_password?(login_params[:password]) && validate_otp(resource)
+          resource.valid_password?(login_params[:password]) && valid_second_factor?(resource)
         end
       end
 
-      private def validate_otp(resource)
+      # /signin stacks two strategies, `two_factor_backupable` ahead of
+      # `two_factor_authenticatable`, so its single field takes either a TOTP
+      # code or one of the backup codes. Accepting only the former here left
+      # the codes the settings screen hands out unusable for signing in — the
+      # one path a user who lost their authenticator has.
+      private def valid_second_factor?(resource)
         return true unless resource.otp_required_for_login
-        return if login_params[:otp_token].nil?
+        return false if login_params[:otp_token].blank?
 
-        resource.validate_and_consume_otp!(login_params[:otp_token])
+        resource.validate_and_consume_otp!(login_params[:otp_token]) ||
+          resource.invalidate_otp_backup_code!(login_params[:otp_token])
       end
 
       private def login_params

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -23,7 +23,7 @@ module Api
         resource = User.find_for_database_authentication(email: login_params[:email])
         return invalid_login_attempt unless resource
 
-        if resource.valid_password?(login_params[:password]) && validate_otp(resource)
+        if valid_credentials?(resource)
           # Stores the session, so the SPA gets a cookie from the same endpoint
           # that hands native clients a token. Each ignores the other's half.
           sign_in(:user, resource)
@@ -64,6 +64,18 @@ module Api
         @jwt_token ||= begin
           auth_params, _options = token_and_options(request)
           JsonWebToken.decode(auth_params)
+        end
+      end
+
+      # Lockable counts attempts from inside `valid_for_authentication?`, which
+      # is what the warden strategies behind /signin go through. Checking the
+      # password on its own skips the counter entirely, so this endpoint could
+      # be hammered indefinitely while the server-rendered form locked the same
+      # account after `maximum_attempts`. It also refuses an already-locked
+      # account holding the right password.
+      private def valid_credentials?(resource)
+        resource.valid_for_authentication? do
+          resource.valid_password?(login_params[:password]) && validate_otp(resource)
         end
       end
 

--- a/docs/vue-spa-migration-plan.md
+++ b/docs/vue-spa-migration-plan.md
@@ -596,6 +596,31 @@ way back in. `POST/PUT /confirmations` and `POST/PUT /unlocks` close that gap.
 Worth checking the same way before each remaining B phase: the ERB screen a
 phase deletes may reach further than the phase's one-line description.
 
+#### Second gap: the session endpoint skipped the strategy chain
+
+Writing the parity coverage the deletion is gated on turned up two ways
+`POST /sessions` did not behave like `/signin`, both from checking the password
+directly instead of through `valid_for_authentication?`:
+
+- **Lockable never counted.** `failed_attempts` stayed at zero however often
+  the endpoint was called, so an account could be hammered through the SPA
+  login while the same account locked after `maximum_attempts` through the
+  ERB form. A locked account holding the right password was refused, but only
+  because `sign_in` trips Devise's activatable hook — which answered with an
+  undocumented 401 from Warden's failure app rather than the endpoint's own
+  error shape.
+- **Backup codes were not accepted.** `/signin` stacks
+  `two_factor_backupable` ahead of `two_factor_authenticatable`, so its one
+  field takes either a TOTP code or a backup code. The endpoint only ever
+  consumed TOTP, which left the codes the B2 settings screen hands out
+  unusable for signing in — the one path back in for a user who lost their
+  authenticator.
+
+Both are closed, with `otp-required`, backup-code and lockout coverage at the
+API level and in Playwright. The gate for deleting the ERB auth views is
+therefore met; what remains for B2 is repointing the mailer links and the
+signup question.
+
 ### Phase C — legacy removal (multi-PR, ~1 week)
 
 Only once B8 has landed and stabilized.

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -4094,7 +4094,8 @@ components:
           type: string
         otp_token:
           type: string
-          description: Required when the account has 2FA enabled.
+          description: Required when the account has 2FA enabled. Takes a TOTP code
+            or one of the account's backup codes.
         remember_me:
           type: boolean
           description: Issue a persistent cookie. Ignored by token clients.

--- a/test/e2e/LoginSecurity.spec.ts
+++ b/test/e2e/LoginSecurity.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "./support/commands"
+import { app, appScenario, appEval } from "./support/on-rails"
+
+// The gate B2 has to clear before the ERB auth views can go: 2FA and the
+// lockout have to hold on the SPA login, not just on /signin.
+test.describe("SPA login security", () => {
+  test.beforeEach(async () => {
+    await app("clean")
+    await appScenario("signed_out_user")
+  })
+
+  test("requires the totp code once 2FA is on", async ({ page }) => {
+    await appEval(`
+      user = User.find_by(email: "will@star.fleet")
+      user.otp_secret = User.generate_otp_secret
+      user.otp_required_for_login = true
+      user.save(validate: false)
+    `)
+
+    await page.goto("/app/login")
+    await page.getByTestId("email").fill("will@star.fleet")
+    await page.getByTestId("password").fill("enterprise")
+    await page.getByTestId("submit").click()
+
+    await expect(page.getByTestId("login-failed")).toBeVisible()
+
+    // The secret is encrypted at rest, so a current code can only come from
+    // the live process.
+    const code = (await appEval(`User.find_by(email: "will@star.fleet").current_otp`)) as string
+
+    await page.getByTestId("otp-token").fill(code)
+    await page.getByTestId("submit").click()
+
+    await expect(page.getByTestId("dashboard-greeting")).toBeVisible()
+  })
+
+  // The one path back in for someone who lost their authenticator, and the
+  // codes the settings screen hands out are worthless without it.
+  test("takes a backup code in the same field", async ({ page }) => {
+    const code = (await appEval(`
+      user = User.find_by(email: "will@star.fleet")
+      user.otp_secret = User.generate_otp_secret
+      user.otp_required_for_login = true
+      codes = user.generate_otp_backup_codes!
+      user.save(validate: false)
+      codes.first
+    `)) as string
+
+    await page.goto("/app/login")
+    await page.getByTestId("email").fill("will@star.fleet")
+    await page.getByTestId("password").fill("enterprise")
+    await page.getByTestId("otp-token").fill(code)
+    await page.getByTestId("submit").click()
+
+    await expect(page.getByTestId("dashboard-greeting")).toBeVisible()
+  })
+
+  test("locks the account when the attempts run out", async ({ page }) => {
+    // Set one short of the limit so the form drives the attempt that locks it,
+    // rather than the spec repeating a round-trip twenty times.
+    await appEval(`
+      User.find_by(email: "will@star.fleet")
+        .update_columns(failed_attempts: User.maximum_attempts - 1)
+    `)
+
+    await page.goto("/app/login")
+    await page.getByTestId("email").fill("will@star.fleet")
+    await page.getByTestId("password").fill("definitely-not-enterprise")
+    await page.getByTestId("submit").click()
+
+    await expect(page.getByTestId("login-failed")).toBeVisible()
+
+    const locked = await appEval(`User.find_by(email: "will@star.fleet").access_locked?`)
+    expect(locked).toBe(true)
+
+    // And from here the right password gets nowhere either — the unlock email
+    // is the only way back in.
+    await page.getByTestId("password").fill("enterprise")
+    await page.getByTestId("submit").click()
+
+    await expect(page.getByTestId("login-failed")).toBeVisible()
+    await expect(page).toHaveURL(/\/app\/login/)
+  })
+})

--- a/test/integration/api/v1/sessions_test.rb
+++ b/test/integration/api/v1/sessions_test.rb
@@ -120,6 +120,59 @@ module Api
         end
       end
 
+      # The account has 2FA on, so the password alone is not enough. Both
+      # factors go through the one endpoint the SPA has.
+      describe "two-factor" do
+        before do
+          data.otp_secret = ::User.generate_otp_secret
+          data.otp_required_for_login = true
+          data.save!
+        end
+
+        it "rejects the password on its own" do
+          assert_api_response :post, 400, body: {email: data.email, password: password} do
+            assert_equal "session.create", parsed_body["code"]
+          end
+        end
+
+        it "accepts a current totp code" do
+          assert_api_response :post, 200, body: {
+            email: data.email, password: password, otp_token: data.current_otp
+          }
+        end
+
+        it "rejects a wrong totp code" do
+          assert_api_response :post, 400, body: {
+            email: data.email, password: password, otp_token: "000000"
+          }
+        end
+
+        # The codes the settings screen hands out are the only way back in for
+        # someone who lost their authenticator, and /signin takes them in this
+        # same field.
+        it "accepts a backup code" do
+          code = data.generate_otp_backup_codes!.first
+          data.save!
+
+          assert_api_response :post, 200, body: {
+            email: data.email, password: password, otp_token: code
+          }
+        end
+
+        it "consumes the backup code it accepted" do
+          code = data.generate_otp_backup_codes!.first
+          data.save!
+
+          assert_api_response :post, 200, body: {
+            email: data.email, password: password, otp_token: code
+          }
+
+          assert_api_response :post, 400, body: {
+            email: data.email, password: password, otp_token: code
+          }
+        end
+      end
+
       # Lockable is live (`lock_strategy = :failed_attempts`,
       # `unlock_strategy = :email`), and the counter has to move on this
       # endpoint too or the SPA login is a way around the lock.

--- a/test/integration/api/v1/sessions_test.rb
+++ b/test/integration/api/v1/sessions_test.rb
@@ -120,6 +120,49 @@ module Api
         end
       end
 
+      # Lockable is live (`lock_strategy = :failed_attempts`,
+      # `unlock_strategy = :email`), and the counter has to move on this
+      # endpoint too or the SPA login is a way around the lock.
+      describe "lockable" do
+        it "counts a wrong password toward the lock" do
+          assert_api_response :post, 400, body: {email: data.email, password: "wrong"}
+
+          assert_equal 1, data.reload.failed_attempts
+        end
+
+        it "locks the account once the attempts run out" do
+          data.update!(failed_attempts: ::User.maximum_attempts - 1)
+
+          assert_api_response :post, 400, body: {email: data.email, password: "wrong"}
+
+          assert data.reload.access_locked?
+        end
+
+        it "mails the unlock instructions when it locks" do
+          data.update!(failed_attempts: ::User.maximum_attempts - 1)
+
+          assert_emails 1 do
+            assert_api_response :post, 400, body: {email: data.email, password: "wrong"}
+          end
+        end
+
+        it "refuses a locked account holding the right password" do
+          data.lock_access!(send_instructions: false)
+
+          assert_api_response :post, 400, body: {email: data.email, password: password} do
+            assert_equal "session.create", parsed_body["code"]
+          end
+        end
+
+        it "clears the counter after a successful sign-in" do
+          data.update!(failed_attempts: 3)
+
+          assert_api_response :post, 200, body: {email: data.email, password: password}
+
+          assert_equal 0, data.reload.failed_attempts
+        end
+      end
+
       describe "destroy" do
         it "is unauthorized without a token" do
           assert_api_response :delete, 401


### PR DESCRIPTION
The Playwright coverage B2 cannot delete the ERB auth views without —
otp-required, backup codes, lockout. Writing it turned out to be impossible
as specified, because two of those three did not work on `POST /sessions`.

## One cause, two gaps

The endpoint checked the password with `valid_password?`, so it never went
through `valid_for_authentication?` — the method Devise's warden strategies
run behind `/signin`.

| | |
|---|---|
| **Lockable never counted** | `failed_attempts` stayed at zero however often the endpoint was called. With `lock_strategy = :failed_attempts` the SPA login was a way around a lock that the ERB form applies after `maximum_attempts`. |
| **Backup codes were refused** | `/signin` stacks `two_factor_backupable` ahead of `two_factor_authenticatable`, so its one field takes a TOTP code *or* a backup code. This endpoint only ever consumed TOTP — leaving the codes #961's settings screen hands out unusable for signing in. |

A locked account holding the right password was already refused, but only as
a side effect: `sign_in` trips Devise's activatable hook, which answered with
an undocumented **401** from Warden's failure app rather than the endpoint's
own error shape. It is now the documented 400.

## Deliberately not mirrored exactly

`/signin` validates the second factor and the password in two separate
`valid_for_authentication?` calls, so a wrong password *and* a wrong code
counts as two failed attempts there. Here it is one attempt per request, and
the OTP is not consumed when the password is already wrong.

## Verification

Both directions, since a test that passes before the fix proves nothing:

- **With the fix** — 318 runs / 1063 assertions, 23/23 Playwright, `vue-tsc`
  clean, standardrb clean, Brakeman no warnings. Schema regenerated; the only
  diff is the `otp_token` description.
- **Without it** — 6 of the 10 new integration tests and 2 of the 3 new e2e
  tests fail.

The TOTP path already worked; that spec is coverage for the gate, not a fix.

## What this leaves for B2

The gate for deleting the ERB auth views is met. Still open: repointing the
mailer links, and the signup question from #961 (`POST /registrations` cannot
create a real account while all three plans are paid).

Unrelated, noticed while setting up a local run: `AGENTS.md`'s "Frontend
modernization in flight" section still names the Hotwire plan as the source
of truth and does not know about the SPA pivot.

🤖
