### PR TITLE
refactor(frontend): move the SPA's colours into theme tokens

### DIFF
--- a/app/frontend/App.vue
+++ b/app/frontend/App.vue
@@ -17,8 +17,8 @@ async function signOut(): Promise<void> {
 <template>
   <!-- White, like the server-rendered layout. `flow-root` stops the auth
        pages' top margin collapsing out and dragging the shell down with it. -->
-  <div class="flow-root min-h-screen bg-white text-ink">
-    <header v-if="currentUser.signedIn" class="border-b border-rule bg-white">
+  <div class="flow-root min-h-screen bg-surface text-ink">
+    <header v-if="currentUser.signedIn" class="border-b border-rule bg-surface">
       <nav class="mx-auto flex max-w-6xl items-center gap-6 px-4 py-3">
         <RouterLink :to="{ name: 'dashboard' }" class="font-semibold">
           {{ t("nav.dashboard") }}

--- a/app/frontend/entrypoints/spa.css
+++ b/app/frontend/entrypoints/spa.css
@@ -8,7 +8,10 @@
  * button chrome.
  *
  * Values below are measured from the Bootstrap 3 login so the two screens
- * match while both exist.
+ * match while both exist. They live here as tokens rather than in the pages
+ * so the planned dark mode and redesign are a swap in this block — a colour
+ * written into a utility class (`text-[#a94442]`) would have to be hunted
+ * down in every page instead.
  */
 
 @import "tailwindcss";
@@ -19,11 +22,21 @@
 @theme {
   --color-brand: #428bca;
   --color-brand-border: #357ebd;
+  --color-brand-hover: #3276b1;
   --color-ink: #333333;
   --color-field: #555555;
   --color-field-border: #cccccc;
+  --color-field-focus: #66afe9;
+  --color-placeholder: #999999;
   --color-rule: #eeeeee;
   --color-muted: #808080;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f5f5f5;
+  --color-control-border: #b9c2cc;
+  --color-control-hover: #e6e6e6;
+  --color-danger: #a94442;
+  --color-warning: #f0ad4e;
+  --color-warning-border: #eea236;
 
   --font-sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-brand: Orbitron, sans-serif;
@@ -35,6 +48,6 @@
     font-size: 14px;
     line-height: 1.428571429;
     color: var(--color-ink);
-    background-color: #fff;
+    background-color: var(--color-surface);
   }
 }

--- a/app/frontend/pages/dashboard/DashboardPage.vue
+++ b/app/frontend/pages/dashboard/DashboardPage.vue
@@ -12,7 +12,7 @@ const currentUser = useCurrentUserStore()
       {{ t("dashboard.title") }}
     </h1>
 
-    <p v-if="currentUser.user" class="mt-2 text-gray-600" data-test="dashboard-greeting">
+    <p v-if="currentUser.user" class="mt-2 text-muted" data-test="dashboard-greeting">
       {{ t("dashboard.greeting", { email: currentUser.user.email }) }}
     </p>
   </div>

--- a/app/frontend/pages/sessions/ConfirmationPage.vue
+++ b/app/frontend/pages/sessions/ConfirmationPage.vue
@@ -75,7 +75,7 @@ const onSubmit = handleSubmit(async (values) => {
     </p>
 
     <template v-else>
-      <p v-if="failed" data-test="confirmation-failed" class="mb-[10px] text-[14px] text-[#a94442]">
+      <p v-if="failed" data-test="confirmation-failed" class="mb-[10px] text-[14px] text-danger">
         {{ t("confirmation.failed") }}
       </p>
 
@@ -91,9 +91,9 @@ const onSubmit = handleSubmit(async (values) => {
             autofocus
             :placeholder="t('login.email')"
             data-test="email"
-            class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+            class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
           />
-          <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-[#a94442]">
+          <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-danger">
             {{ errors.email }}
           </p>
         </div>
@@ -102,7 +102,7 @@ const onSubmit = handleSubmit(async (values) => {
           type="submit"
           data-test="submit"
           :disabled="isSubmitting"
-          class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-[#3276b1] disabled:opacity-65"
+          class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-brand-hover disabled:opacity-65"
         >
           {{ isSubmitting ? t("login.submitting") : t("confirmation.resend") }}
         </button>

--- a/app/frontend/pages/sessions/LoginPage.vue
+++ b/app/frontend/pages/sessions/LoginPage.vue
@@ -91,9 +91,9 @@ const onSubmit = handleSubmit(async (values) => {
           autofocus
           :placeholder="t('login.email')"
           data-test="email"
-          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
         />
-        <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-[#a94442]">
+        <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-danger">
           {{ errors.email }}
         </p>
       </div>
@@ -106,9 +106,9 @@ const onSubmit = handleSubmit(async (values) => {
           autocomplete="current-password"
           :placeholder="t('login.password')"
           data-test="password"
-          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
         />
-        <p v-if="errors.password" data-test="password-error" class="mt-1 text-[13px] text-[#a94442]">
+        <p v-if="errors.password" data-test="password-error" class="mt-1 text-[13px] text-danger">
           {{ errors.password }}
         </p>
       </div>
@@ -122,7 +122,7 @@ const onSubmit = handleSubmit(async (values) => {
           autocomplete="one-time-code"
           :placeholder="t('login.otpToken')"
           data-test="otp-token"
-          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
         />
       </div>
 
@@ -132,14 +132,14 @@ const onSubmit = handleSubmit(async (values) => {
           v-model="rememberMe"
           type="checkbox"
           data-test="remember-me"
-          class="h-[18px] w-[18px] rounded-[4px] border border-[#b9c2cc] accent-brand"
+          class="h-[18px] w-[18px] rounded-[4px] border border-control-border accent-brand"
         />
         <label for="remember-me" class="text-[14px] font-normal text-muted">
           {{ t("login.rememberMe") }}
         </label>
       </div>
 
-      <p v-if="failed" data-test="login-failed" class="mb-[10px] text-[14px] text-[#a94442]">
+      <p v-if="failed" data-test="login-failed" class="mb-[10px] text-[14px] text-danger">
         {{ t("login.failed") }}
       </p>
 
@@ -147,7 +147,7 @@ const onSubmit = handleSubmit(async (values) => {
         type="submit"
         data-test="submit"
         :disabled="isSubmitting"
-        class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-[#3276b1] disabled:opacity-65"
+        class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-brand-hover disabled:opacity-65"
       >
         {{ isSubmitting ? t("login.submitting") : t("login.submit") }}
       </button>
@@ -171,7 +171,7 @@ const onSubmit = handleSubmit(async (values) => {
         <a
           href="/signup"
           data-test="sign-up"
-          class="block w-full rounded border border-field-border bg-white px-3 py-[6px] text-center text-[14px] text-ink hover:bg-[#e6e6e6]"
+          class="block w-full rounded border border-field-border bg-surface px-3 py-[6px] text-center text-[14px] text-ink hover:bg-control-hover"
         >
           {{ t("login.signUp") }}
         </a>

--- a/app/frontend/pages/sessions/PasswordResetPage.vue
+++ b/app/frontend/pages/sessions/PasswordResetPage.vue
@@ -66,9 +66,9 @@ const onSubmit = handleSubmit(async (values) => {
           autofocus
           :placeholder="t('passwordReset.password')"
           data-test="password"
-          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
         />
-        <p v-if="errors.password" data-test="password-error" class="mt-1 text-[13px] text-[#a94442]">
+        <p v-if="errors.password" data-test="password-error" class="mt-1 text-[13px] text-danger">
           {{ errors.password }}
         </p>
       </div>
@@ -81,11 +81,11 @@ const onSubmit = handleSubmit(async (values) => {
           autocomplete="new-password"
           :placeholder="t('passwordReset.passwordConfirmation')"
           data-test="password-confirmation"
-          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
         />
       </div>
 
-      <p v-if="failed" data-test="reset-failed" class="mb-[10px] text-[14px] text-[#a94442]">
+      <p v-if="failed" data-test="reset-failed" class="mb-[10px] text-[14px] text-danger">
         {{ t("passwordReset.failed") }}
       </p>
 
@@ -93,7 +93,7 @@ const onSubmit = handleSubmit(async (values) => {
         type="submit"
         data-test="submit"
         :disabled="isSubmitting"
-        class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-[#3276b1] disabled:opacity-65"
+        class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-brand-hover disabled:opacity-65"
       >
         {{ isSubmitting ? t("login.submitting") : t("passwordReset.resetSubmit") }}
       </button>

--- a/app/frontend/pages/sessions/PasswordResetRequestPage.vue
+++ b/app/frontend/pages/sessions/PasswordResetRequestPage.vue
@@ -58,14 +58,14 @@ const onSubmit = handleSubmit(async (values) => {
           autofocus
           :placeholder="t('login.email')"
           data-test="email"
-          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
         />
-        <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-[#a94442]">
+        <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-danger">
           {{ errors.email }}
         </p>
       </div>
 
-      <p v-if="failed" data-test="reset-failed" class="mb-[10px] text-[14px] text-[#a94442]">
+      <p v-if="failed" data-test="reset-failed" class="mb-[10px] text-[14px] text-danger">
         {{ t("passwordReset.failed") }}
       </p>
 
@@ -73,7 +73,7 @@ const onSubmit = handleSubmit(async (values) => {
         type="submit"
         data-test="submit"
         :disabled="isSubmitting"
-        class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-[#3276b1] disabled:opacity-65"
+        class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-brand-hover disabled:opacity-65"
       >
         {{ isSubmitting ? t("login.submitting") : t("passwordReset.requestSubmit") }}
       </button>

--- a/app/frontend/pages/sessions/UnlockPage.vue
+++ b/app/frontend/pages/sessions/UnlockPage.vue
@@ -72,7 +72,7 @@ const onSubmit = handleSubmit(async (values) => {
     </p>
 
     <template v-else>
-      <p v-if="failed" data-test="unlock-failed" class="mb-[10px] text-[14px] text-[#a94442]">
+      <p v-if="failed" data-test="unlock-failed" class="mb-[10px] text-[14px] text-danger">
         {{ t("unlock.failed") }}
       </p>
 
@@ -88,9 +88,9 @@ const onSubmit = handleSubmit(async (values) => {
             autofocus
             :placeholder="t('login.email')"
             data-test="email"
-            class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+            class="block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
           />
-          <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-[#a94442]">
+          <p v-if="errors.email" data-test="email-error" class="mt-1 text-[13px] text-danger">
             {{ errors.email }}
           </p>
         </div>
@@ -99,7 +99,7 @@ const onSubmit = handleSubmit(async (values) => {
           type="submit"
           data-test="submit"
           :disabled="isSubmitting"
-          class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-[#3276b1] disabled:opacity-65"
+          class="block w-full rounded-md border border-brand-border bg-brand px-4 py-[10px] text-[18px] font-normal text-white hover:bg-brand-hover disabled:opacity-65"
         >
           {{ isSubmitting ? t("login.submitting") : t("unlock.resend") }}
         </button>

--- a/app/frontend/pages/settings/TwoFactorPage.vue
+++ b/app/frontend/pages/settings/TwoFactorPage.vue
@@ -88,7 +88,7 @@ async function regenerate(): Promise<void> {
       {{ t("twoFactor.title") }}
     </h1>
 
-    <p v-if="failed" data-test="two-factor-failed" class="mb-4 text-[14px] text-[#a94442]">
+    <p v-if="failed" data-test="two-factor-failed" class="mb-4 text-[14px] text-danger">
       {{ t("twoFactor.failed") }}
     </p>
 
@@ -96,7 +96,7 @@ async function regenerate(): Promise<void> {
          codes in the clear and never again. -->
     <div v-if="codes" class="mb-6" data-test="backup-codes">
       <p class="mb-2 text-[14px]">{{ t("twoFactor.backupExplain") }}</p>
-      <pre class="max-w-sm rounded border border-field-border bg-[#f5f5f5] p-3 text-[13px]">{{ codes.join("\n") }}</pre>
+      <pre class="max-w-sm rounded border border-field-border bg-surface-muted p-3 text-[13px]">{{ codes.join("\n") }}</pre>
     </div>
 
     <template v-if="enabled">
@@ -106,7 +106,7 @@ async function regenerate(): Promise<void> {
         type="button"
         data-test="regenerate-codes"
         :disabled="busy"
-        class="mb-6 rounded border border-[#eea236] bg-[#f0ad4e] px-4 py-2 text-[14px] text-white disabled:opacity-65"
+        class="mb-6 rounded border border-warning-border bg-warning px-4 py-2 text-[14px] text-white disabled:opacity-65"
         @click="regenerate"
       >
         {{ t("twoFactor.backupCodes") }}
@@ -120,7 +120,7 @@ async function regenerate(): Promise<void> {
           autocomplete="one-time-code"
           :placeholder="t('twoFactor.otpToken')"
           data-test="otp-token"
-          class="mb-3 block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          class="mb-3 block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
         />
         <button
           type="submit"
@@ -140,7 +140,7 @@ async function regenerate(): Promise<void> {
 
       <pre
         v-if="provisioningUri"
-        class="mb-4 max-w-lg overflow-x-auto rounded border border-field-border bg-[#f5f5f5] p-3 text-[12px]"
+        class="mb-4 max-w-lg overflow-x-auto rounded border border-field-border bg-surface-muted p-3 text-[12px]"
         data-test="provisioning-uri"
         >{{ provisioningUri }}</pre
       >
@@ -153,7 +153,7 @@ async function regenerate(): Promise<void> {
           autocomplete="one-time-code"
           :placeholder="t('twoFactor.otpToken')"
           data-test="otp-token"
-          class="mb-3 block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-[#999] focus:border-[#66afe9] focus:outline-none"
+          class="mb-3 block w-full rounded border border-field-border p-[10px] text-[16px] text-field placeholder:text-placeholder focus:border-field-focus focus:outline-none"
         />
         <button
           type="submit"

--- a/app/frontend/theme-tokens.spec.ts
+++ b/app/frontend/theme-tokens.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+
+// Colours belong in spa.css's `@theme` block. The dark mode and redesign
+// planned for phase C (docs/vue-spa-migration-plan.md) are meant to be a swap
+// in that one block, which only holds while no page carries a colour of its
+// own — and the SPA had accumulated 46 such colours before they were pulled
+// into tokens. Six more domains get ported in B3–B8, so the habit is checked
+// here rather than left to review.
+// vitest runs from the repo root — `include` in vitest.config.mts is
+// root-relative too.
+const root = join(process.cwd(), "app/frontend")
+
+const sources = readdirSync(root, {recursive: true, encoding: "utf8"})
+  .filter((file) => file.endsWith(".vue") || (file.endsWith(".ts") && !file.endsWith(".spec.ts")))
+  .map((file) => ({file, body: readFileSync(join(root, file), "utf8")}))
+
+const hits = (pattern: RegExp, scope = (file: string) => true) =>
+  sources
+    .filter(({file}) => scope(file))
+    .flatMap(({file, body}) => [...body.matchAll(pattern)].map((match) => `${file}: ${match[0]}`))
+
+const PALETTE =
+  "slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose"
+
+describe("colour tokens", () => {
+  it("reads the frontend sources", () => {
+    expect(sources.length).toBeGreaterThan(20)
+  })
+
+  it("writes no raw colour into a utility class", () => {
+    expect(hits(/-\[#[0-9a-fA-F]{3,8}\]/g)).toEqual([])
+  })
+
+  // `text-white` stays allowed: it is a foreground paired with its own fill
+  // (the brand and warning buttons), not a surface, and it survives a dark
+  // theme unchanged. A surface has to come from a token.
+  it("takes surfaces from tokens rather than white or black", () => {
+    expect(hits(/\b(?:bg|border|from|via|to)-(?:white|black)\b/g)).toEqual([])
+  })
+
+  // Scoped to pages: `ToastHost.vue` still paints its success/info/error
+  // variants from the Tailwind palette. Those need semantic tokens whose
+  // values are a design decision, so they are the redesign's to make, not a
+  // mechanical rename's.
+  it("keeps the Tailwind palette out of the pages", () => {
+    expect(hits(new RegExp(`\\b(?:bg|text|border)-(?:${PALETTE})-[0-9]{2,3}\\b`, "g"), (file) =>
+      file.startsWith("pages/")
+    )).toEqual([])
+  })
+})

--- a/docs/vue-spa-migration-plan.md
+++ b/docs/vue-spa-migration-plan.md
@@ -619,6 +619,21 @@ Only once B8 has landed and stabilized.
 Exit: `rg 'angular|jquery|coffee|bootstrap'` over `app/` returns nothing but
 PDF-template hits.
 
+#### Dark mode and the redesign come after, not during
+
+A **dark mode and a general visual redesign are planned**, and both wait for
+this phase deliberately. While old and new screens coexist a user crosses
+between them constantly, so the SPA replicates the Bootstrap 3 look on
+purpose — `spa.css` measures its values off the server-rendered login.
+Redesigning during B3–B8 would mean styling fifty-odd screens to a look that
+then gets thrown away, and leaving the app half-and-half for months.
+
+What that costs now is a habit rather than work: colours belong in the
+`@theme` block in `app/frontend/entrypoints/spa.css`, never written into a
+utility class as a raw value (`text-[#a94442]`). Tokens make the redesign a
+swap in one block; raw values would have to be hunted through every page.
+Preflight going on in this phase is the moment the palette is free to change.
+
 ## Testing strategy
 
 | Layer | Tool | Notes |


### PR DESCRIPTION
Groundwork for the dark mode and the redesign that follow the migration. No
visual change — that is the whole point, and it is verified rather than
asserted (below).

## What was wrong

Nine colours sat directly in utility classes across six page files: 46
occurrences counting `bg-white`.

| Was | Now | Where it comes from |
|---|---|---|
| `text-[#a94442]` ×12 | `text-danger` | Bootstrap's error text |
| `placeholder:text-[#999]` ×10 | `placeholder:text-placeholder` | input placeholder |
| `focus:border-[#66afe9]` ×10 | `focus:border-field-focus` | focused input |
| `hover:bg-[#3276b1]` ×5 | `hover:bg-brand-hover` | `.btn-primary:hover` |
| `bg-white` ×3 | `bg-surface` | page and header ground |
| `bg-[#f5f5f5]` ×2 | `bg-surface-muted` | `<pre>` blocks |
| `hover:bg-[#e6e6e6]` | `hover:bg-control-hover` | `.btn-default:hover` |
| `bg-[#f0ad4e]` / `border-[#eea236]` | `bg-warning` / `border-warning-border` | `.btn-warning` |
| `border-[#b9c2cc]` | `border-control-border` | checkbox border |

Every value carries over byte-identical. `#999` becomes `#999999`, the same
colour spelled in full. The base layer's hardcoded `#fff` now reads
`var(--color-surface)`.

`text-white` on a brand or warning fill is left alone: that is a foreground
paired with its own fill, not a surface, and it stays white in a dark theme.

## Why now

The values are Bootstrap 3's on purpose — `spa.css` measures them off
`/signin` so a user crossing between old and new screens sees one design. That
parity holds until Phase C. But every further domain ported in B3–B8 adds more
literals, so the cheap moment to establish the seam is before those land, not
after. With tokens the redesign is a swap in one block.

## The convention is now checked, not just written down

Greptile's review pointed out that the token rule lived only in the plan
document, so nothing stopped the next ported domain from reintroducing what
this branch removed. `app/frontend/theme-tokens.spec.ts` now scans the
frontend sources for three things and runs in the existing js-tests job:

- raw colours in utility classes (`text-[#a94442]`)
- `bg-`/`border-`/gradient white and black, since a surface has to come from a token
- Tailwind palette colours inside `pages/`

Verified by injecting one of each violation and watching all three fail, then
reverting.

That third rule caught a holdover the rename had missed: the dashboard
greeting was `text-gray-600`, now `text-muted`. **It is the one place on this
branch where a colour actually changes** — #4b5563 to #808080 — and it puts
the line on the token that exists for muted text.

`text-white` stays allowed, and `ToastHost.vue` keeps its palette-coloured
success/info/error variants, which is why the palette rule stops at `pages/`.
Semantic tokens for toasts need values chosen rather than renamed, so they
belong to the redesign.

## Verification

A throwaway Playwright spec captured full-page screenshots of ten states
before the refactor — login default, validation errors, rejected credentials,
focused field, hovered secondary button, password-reset request, failed
unlock, failed confirmation, 2FA enabled, 2FA rejected — then ran twice to
prove the baselines were deterministic. After the refactor all ten matched
pixel for pixel. The spec and its snapshots are not committed.

One state could not be baselined: the 2FA enrollment view calls
`POST /me/otp` on mount, minting a fresh secret each visit, so its QR code and
provisioning URI differ every run. Its `<pre>` is checked by computed style
instead — `rgb(245, 245, 245)` on the background, `rgb(204, 204, 204)` on the
border.

Also green: `vue-tsc`, 46 Vitest, 20/20 Playwright.

🤖
