### PR TITLE
fix(dev): resolve dev secrets through 1Password and start vite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ read after the template.
 ### Development
 
 ```bash
-bin/op foreman start -f Procfile.dev  # Rails + sidekiq + (legacy) assets
+bin/dev                               # Rails + sidekiq + vite (see --help)
 bin/op rails console
 bin/op rake db:migrate
 ```

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,3 @@
 web: ./bin/rails s
 worker: ./bin/sidekiq -C config/sidekiq.yml -v
 vite: ./bin/vite dev
-docker-compose: docker compose up

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,4 @@
-web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq
+web: ./bin/rails s
+worker: ./bin/sidekiq -C config/sidekiq.yml -v
+vite: ./bin/vite dev
+docker-compose: docker compose up

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,0 @@
-web: ./bin/rails s
-worker: ./bin/sidekiq -C config/sidekiq.yml -v
-docker-compose: docker compose up
-vite: bin/vite dev

--- a/bin/dev
+++ b/bin/dev
@@ -8,7 +8,7 @@ if [ -f .env.local ]; then
 fi
 
 dev_port="${PORT:-8240}"
-services=(web worker)
+services=(web worker vite)
 
 for arg in "$@"; do
   case "$arg" in
@@ -17,12 +17,13 @@ for arg in "$@"; do
     --open)        open_browser=1 ;;
     --no-web)      no_web=1 ;;
     --no-worker)   no_worker=1 ;;
+    --no-vite)     no_vite=1 ;;
     --only=*)      only="${arg#--only=}" ;;
     --help|-h)
       cat <<EOF
 Usage: bin/dev [OPTIONS]
 
-Start the development server (Rails, Sidekiq).
+Start the development server (Rails, Sidekiq, Vite).
 
 Options:
   --docker       Include Docker Compose services
@@ -31,10 +32,11 @@ Options:
 
   --no-web       Skip Rails server
   --no-worker    Skip Sidekiq worker
+  --no-vite      Skip Vite dev server
 
   --only=SVC     Start only the listed services (comma-separated)
-                 Available: web, worker
-                 Example: --only=web
+                 Available: web, worker, vite
+                 Example: --only=web,vite
 
   --help         Show this help message
 EOF
@@ -48,7 +50,7 @@ EOF
   esac
 done
 
-if [ -n "$only" ] && { [ -n "$no_web" ] || [ -n "$no_worker" ]; }; then
+if [ -n "$only" ] && { [ -n "$no_web" ] || [ -n "$no_worker" ] || [ -n "$no_vite" ]; }; then
   echo "Error: --only and --no-* flags cannot be combined." >&2
   exit 1
 fi
@@ -60,12 +62,13 @@ fi
 
 # Determine which services to start
 if [ -n "$only" ]; then
-  run_web=0; run_worker=0
+  run_web=0; run_worker=0; run_vite=0
   IFS=',' read -ra selected <<< "$only"
   for svc in "${selected[@]}"; do
     case "$svc" in
       web)    run_web=1 ;;
       worker) run_worker=1 ;;
+      vite)   run_vite=1 ;;
       *)
         echo "Unknown service: $svc (available: ${services[*]})" >&2
         exit 1
@@ -73,15 +76,16 @@ if [ -n "$only" ]; then
     esac
   done
 else
-  run_web=1; run_worker=1
+  run_web=1; run_worker=1; run_vite=1
   [ -n "$no_web" ]    && run_web=0
   [ -n "$no_worker" ] && run_worker=0
+  [ -n "$no_vite" ]   && run_vite=0
 fi
 
 run_docker=0
 [ -n "$use_docker" ] && run_docker=1
 
-formation="web=${run_web},worker=${run_worker},docker-compose=${run_docker}"
+formation="web=${run_web},worker=${run_worker},vite=${run_vite},docker-compose=${run_docker}"
 
 if ! gem list foreman -i --silent; then
   echo "Installing foreman..."

--- a/bin/dev
+++ b/bin/dev
@@ -12,7 +12,6 @@ services=(web worker vite)
 
 for arg in "$@"; do
   case "$arg" in
-    --docker)      use_docker=1 ;;
     --rdbg)        use_rdbg=1 ;;
     --open)        open_browser=1 ;;
     --no-web)      no_web=1 ;;
@@ -26,7 +25,6 @@ Usage: bin/dev [OPTIONS]
 Start the development server (Rails, Sidekiq, Vite).
 
 Options:
-  --docker       Include Docker Compose services
   --rdbg         Attach Ruby debugger (rdbg) to the Rails server
   --open         Open browser when server is ready
 
@@ -82,10 +80,7 @@ else
   [ -n "$no_vite" ]   && run_vite=0
 fi
 
-run_docker=0
-[ -n "$use_docker" ] && run_docker=1
-
-formation="web=${run_web},worker=${run_worker},vite=${run_vite},docker-compose=${run_docker}"
+formation="web=${run_web},worker=${run_worker},vite=${run_vite}"
 
 if ! gem list foreman -i --silent; then
   echo "Installing foreman..."

--- a/bin/dev
+++ b/bin/dev
@@ -103,4 +103,4 @@ if [ -n "$open_browser" ]; then
   ) &
 fi
 
-exec foreman start -f Procfile.dev -m "$formation" -p "$dev_port" -e /dev/null
+exec foreman start -f Procfile -m "$formation" -p "$dev_port" -e /dev/null

--- a/bin/dev
+++ b/bin/dev
@@ -107,4 +107,4 @@ if [ -n "$open_browser" ]; then
   ) &
 fi
 
-exec foreman start -f Procfile -m "$formation" -p "$dev_port" -e /dev/null
+exec bin/op foreman start -f Procfile -m "$formation" -p "$dev_port" -e /dev/null

--- a/bin/setup
+++ b/bin/setup
@@ -151,7 +151,7 @@ if ARGV.include?("--help") || ARGV.include?("-h")
       --port=N        Override the Rails port (default: derived from name)
       --vite-port=N   Override the Vite dev server port (default: derived from name)
       --dev           Start the development server after setup
-      --dev-<flag>    Forward --<flag> to bin/dev (e.g. --dev-docker, --dev-open)
+      --dev-<flag>    Forward --<flag> to bin/dev (e.g. --dev-open, --dev-rdbg)
       --verbose       Show full command output (default: concise status lines)
       --help          Show this help message
   HELP


### PR DESCRIPTION
Brings the dev entry point in line with fleetyards, which has the same
`bin/dev` / `bin/op` / `.env.tpl` setup but wires it together.

### `bin/dev` never resolved 1Password

#940 added `bin/op`, `.env.tpl` and the vault-backed credentials helper, and
wired them into deploy and credentials — but not into `bin/dev`, which kept
running bare `foreman` with `-e /dev/null`. The `op://` references in
`.env.tpl` were never resolved.

That was invisible because the secrets have fallbacks: `SECRET_KEY_BASE` and
the devise secrets are `ENV.fetch(..., credentials.x)`, and with no
`config/master.key` on disk credentials return `nil` too, so Rails quietly
fell back to `tmp/local_secret.txt`. Sessions worked; the secret-dependent
paths didn't.

Before:

```
SECRET_KEY_BASE in ENV? false
JWT encode RAISED: JWT::DecodeError: HMAC key expected to be a String
```

After:

```
SECRET_KEY_BASE in ENV? true
DEVISE_JWT_SECRET in ENV? true
DEVISE_OTP_SECRET in ENV? true
secret_key_base len: 130
JWT encode: OK
```

So the API token path was broken outright under `bin/dev`, and OTP could not
validate tokens against an imported production dump — the exact case
`.env.tpl` documents.

### The vite process never started

`foreman`'s `-m` formation is an allowlist, not a set of overrides — a process
absent from it gets concurrency 0, verified against a stub Procfile:

```
$ foreman start -f Procfile.stub -m "web=1,worker=1"
web.1    | WEB_RAN
worker.1 | WORKER_RAN      # VITE_RAN never appears
```

`Procfile.dev` declared `vite:` but the formation string listed only
`web`/`worker`/`docker-compose`. Not fatal, since `config/vite.json` sets
`autoBuild: true` for development, so you got full rebuilds on request
instead of HMR.

### One Procfile

The production `Procfile` had been unreferenced since the container move:
kamal runs the web role off the Dockerfile `CMD` (`puma -C config/puma.rb`)
and gives the worker role an explicit `cmd`, so both of its entries were dead
duplicates. `Procfile.dev` takes its place, as in fleetyards.

One caveat worth a second opinion: Heroku reads `Procfile` by convention with
no textual reference, so it's the one consumer grep can't rule out. The
evidence says that path is long dead — no heroku remote, `app.json` last
touched 2022-08-18 and every env var it declares (`DROPBOX_KEY`,
`STRIPE_SECRET`, `WTI_KEY`, `SMTP_*`, …) unused in the codebase. But
`README.md` still has a deploy button and `lib/tasks/heroku.thor` still pushes
to `git@heroku.com`. Deleting those three is a separate cleanup.

### `--docker` dropped

`bin/setup` already starts Docker with `docker compose up -d --wait
--wait-timeout 30`, so setup blocks until postgres and redis are healthy, and
`AGENTS.md` documents the same command as its own step. The foreman-managed
copy ran attached with no health gate and duplicated state that's shared
across worktrees — the worse of the two paths. So the flag, the
`docker-compose` process and the now-invalid `--dev-docker` example in
`bin/setup`'s help all go.

`bin/dev --docker` now fails loudly rather than being quietly accepted.
fleetyards loses the same flag in fleetyards/fleetyards#4749, where it never
worked at all — its Procfile has never declared the process.

### Deliberate deviation from fleetyards

Also did **not** copy fleetyards' `.env` entry in `bin/op`'s env-file list
(caught by Greptile on the first push). `op run` applies `--env-file` in
order, later wins:

```
$ op run --env-file=a.env --env-file=b.env -- printenv GREPTILE_TEST
from_dotenv
```

So a `.env` loaded after `.env.tpl` shadows the vault values. Pre-migration
`.env.example` held `SECRET_KEY_BASE`, `DEVISE_SECRET` and
`DEVISE_OTP_SECRET`, so any developer with an old `.env` on disk would have
had those three override 1Password — reintroducing this bug in a quieter
form, with wrong values instead of a nil that raises. It also buys nothing,
since `dotenv-rails` already loads `.env` at boot for the plain-`bin/rails`
case. `bin/op` is unchanged by this PR; overrides stay in `.env.local` as
documented. Worth fixing in fleetyards, which has the same latent hazard.

### Note for reviewers

`secret_key_base` changes from the 128-char `tmp/local_secret.txt` to the
130-char vault value, so existing dev session cookies are invalidated once
and you'll be logged out on the next boot. `.env.tpl` points at the `_LIVE`
items by design.

If 1Password is unlocked via the desktop-app integration you won't see a
prompt — it just resolves. `bin/op` errors with install instructions when the
CLI is missing.

🤖


