### PR TITLE
fix(spa): full reload on the handover, and a Vite dev server that reaches reckoning.test

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -40,8 +40,12 @@
     frontend migration (docs/frontend-migration-plan.md). The application
     entrypoint is empty in Phase 1; tailwind.css ships utility classes
     without preflight (Phase 2) so Tailwind and Bootstrap 3 coexist. %>
+<%# `turbo-track` because the SPA shell is a different document: crossing into
+    `/app` has to be a full page load, not a Turbo Drive head merge. A merge
+    keeps Bootstrap loaded, and unlayered CSS beats Tailwind's `@layer`
+    utilities, so the SPA renders unstyled. %>
 <%= vite_client_tag %>
-<%= vite_stylesheet_tag "tailwind.css" %>
-<%= vite_typescript_tag "application" %>
+<%= vite_stylesheet_tag "tailwind.css", data: {turbo_track: "reload"} %>
+<%= vite_typescript_tag "application", data: {turbo_track: "reload"} %>
 
 <%= csrf_meta_tags %>

--- a/app/views/layouts/spa.html.erb
+++ b/app/views/layouts/spa.html.erb
@@ -15,8 +15,8 @@
         `tailwind.css` because this document needs Tailwind's preflight, which
         the shared one omits to avoid disturbing Bootstrap 3. %>
     <%= vite_client_tag %>
-    <%= vite_stylesheet_tag "spa.css" %>
-    <%= vite_typescript_tag "frontend" %>
+    <%= vite_stylesheet_tag "spa.css", data: {turbo_track: "reload"} %>
+    <%= vite_typescript_tag "frontend", data: {turbo_track: "reload"} %>
 
     <%= appsignal_meta_tags %>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,20 +21,26 @@ Rails.application.config.content_security_policy do |policy|
     "https://ka-p.fontawesome.com", "https://www.gstatic.com"
   ]
 
+  # The Vite dev server is served from its own origin (skipProxy), so its assets,
+  # HMR socket and injected styles need to be allowed explicitly.
+  vite_hosts = []
   if Rails.env.development?
-    connect_src.concat [
-      "ws://localhost:3035", "http://localhost:3035",
-      "ws://reckoning.test:3035", "http://reckoning.test:3035", "ws://reckoning.test:3036"
-      # "ws://#{ViteRuby.config.host_with_port}"
-    ]
+    vite_hosts = [
+      ViteRuby.config.host, "localhost", "127.0.0.1",
+      Rails.configuration.app.domain.split(":").first
+    ].compact.uniq
   end
+  vite_http = vite_hosts.map { |host| "http://#{host}:#{ViteRuby.config.port}" }
+  vite_ws = vite_hosts.map { |host| "ws://#{host}:#{ViteRuby.config.port}" }
+
+  connect_src.concat(vite_http + vite_ws)
 
   script_src = [
     :self, :unsafe_inline, :unsafe_eval, :blob, "https://kit.fontawesome.com",
     "https://kit-pro.fontawesome.com", "https://kit-free.fontawesome.com",
     "https://www.gstatic.com"
   ]
-  # script_src << "http://#{ViteRuby.config.host_with_port}" if Rails.env.development?
+  script_src.concat(vite_http)
 
   worker_src = %i[self blob]
 
@@ -43,6 +49,7 @@ Rails.application.config.content_security_policy do |policy|
     "https://kit-pro.fontawesome.com", "https://kit-free.fontawesome.com",
     "https://ka-p.fontawesome.com"
   ]
+  style_src.concat(vite_http)
 
   img_src = [
     :self, :data, :blob, Rails.application.credentials.carrierwave_cloud_cdn_endpoint,
@@ -62,19 +69,13 @@ Rails.application.config.content_security_policy do |policy|
   policy.manifest_src :self
   policy.form_action :self
   policy.connect_src(*connect_src)
-  # Allow @vite/client to hot reload changes in development
-  #    policy.connect_src *policy.connect_src, "ws://#{ ViteRuby.config.host_with_port }" if Rails.env.development?
 
   policy.script_src(*script_src)
-  # Allow @vite/client to hot reload javascript changes in development
-  #    policy.script_src *policy.script_src, :unsafe_eval, "http://#{ ViteRuby.config.host_with_port }" if Rails.env.development?
 
   # You may need to enable this in production as well depending on your setup.
   #    policy.script_src *policy.script_src, :blob if Rails.env.test?
 
   policy.style_src(*style_src)
-  # Allow @vite/client to hot reload style changes in development
-  #    policy.style_src *policy.style_src, :unsafe_inline if Rails.env.development?
 
   policy.img_src(*img_src)
   policy.font_src(*font_src)

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -64,5 +64,17 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
       assert_response :ok
     end
+
+    # The other half of the handover: crossing into `/app` has to be a full
+    # page load. A Turbo Drive head merge keeps Bootstrap's unlayered CSS
+    # around, and that beats Tailwind's `@layer` utilities.
+    it "marks the shared layout's assets as a full reload" do
+      sign_in will
+
+      get "/projects/#{project.id}"
+
+      assert_select "link[data-turbo-track=?]", "reload"
+      assert_select "script[data-turbo-track=?]", "reload"
+    end
   end
 end

--- a/test/controllers/spa_controller_test.rb
+++ b/test/controllers/spa_controller_test.rb
@@ -45,6 +45,16 @@ class SpaControllerTest < ActionDispatch::IntegrationTest
     ActionController::Base.allow_forgery_protection = original
   end
 
+  # Crossing between the two documents has to be a full page load. A Turbo
+  # Drive head merge keeps Bootstrap's unlayered CSS around, and that beats
+  # Tailwind's `@layer` utilities — the SPA then renders unstyled.
+  it "makes the shell's assets a full reload for turbo drive" do
+    get "/app"
+
+    assert_select "link[data-turbo-track=?]", "reload"
+    assert_select "script[data-turbo-track=?]", "reload"
+  end
+
   # The shell must not drag in Bootstrap or the Sprockets bundle.
   it "does not load the legacy asset pipeline" do
     get "/app"

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -4,8 +4,20 @@ import tailwindcss from "@tailwindcss/vite"
 import vue from "@vitejs/plugin-vue"
 import { fileURLToPath } from "node:url"
 
+const devOrigins = [
+  /^https?:\/\/(?:[^.]+\.)?localhost(?::\d+)?$/,
+  /^https?:\/\/127\.0\.0\.1(?::\d+)?$/,
+  /^https?:\/\/(?:[^.]+\.)?reckoning\.test(?::\d+)?$/,
+]
+
 export default defineConfig({
   plugins: [RubyPlugin(), tailwindcss(), vue()],
+  // Rails serves the app from reckoning.test while Vite serves its assets from
+  // its own port, and Vite only sends CORS headers to localhost by default.
+  server: {
+    allowedHosts: [".reckoning.test"],
+    cors: { origin: devOrigins },
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./app/frontend", import.meta.url)),


### PR DESCRIPTION
Zwei Fixes, die in meinem Arbeitsbaum lagen und weder auf `main` noch in einem der Migrations-PRs stecken. Sie sind unabhängig von der B7-Kette und gehen direkt gegen `main`.

## 1. Der Übergang zwischen den beiden Dokumenten muss ein echter Seitenwechsel sein

Der Sprung nach `/app` war eine Turbo-Drive-Navigation, also hat Turbo die beiden `<head>` zusammengeführt statt ein neues Dokument zu laden. Dabei bleibt Bootstrap geladen — und unlayered CSS gewinnt gegen Tailwinds `@layer`-Utilities. Ergebnis: die SPA rendert mit allen Klassen im Markup und keiner davon wirksam.

`data-turbo-track="reload"` an den Entrypoints **beider** Layouts macht das Überqueren wieder zu einem Seitenladen. Das betrifft die Produktion, nicht nur die Entwicklung.

Abgesichert in beide Richtungen: `spa_controller_test` prüft die Hülle, `projects_controller_test` das geteilte ERB-Layout — mit dem Grund im Kommentar, damit das Attribut nicht bei der nächsten Layout-Änderung stillschweigend verschwindet.

## 2. Der Vite-Dev-Server war von reckoning.test aus nicht erreichbar

Der Dev-Server läuft mit `skipProxy`, liefert also von seinem eigenen Origin. Zwei Dinge standen dem im Weg:

- Die CSP erlaubte feste Ports (`localhost:3035`, `reckoning.test:3035`, `:3036`), teils auskommentiert, und passte damit nicht zu `config/vite.json` (Dev-Port 3036). Jetzt leitet sie die erlaubten Origins aus `ViteRuby.config` und der konfigurierten Domain ab — und nur in Development; in Produktion bleiben die Listen unverändert leer.
- Vite schickt CORS-Header standardmäßig nur an localhost. `server.allowedHosts` plus `server.cors.origin` decken jetzt `*.reckoning.test`, `localhost` und `127.0.0.1` ab.

Reine Entwicklungsumgebung, ohne Wirkung auf den Produktionsbuild.

## Geprüft

372 Ruby-Tests (2 davon neu), standardrb und Brakeman ohne Befund. 🤖