### PR TITLE
fix(users): let gravatar draw the avatar fallback itself

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,8 +48,14 @@ class User < ApplicationRecord
     UserMailer.welcome_mail(self, token).deliver
   end
 
+  # `d=identicon` lets Gravatar draw the fallback itself. It used to point at
+  # identicons.github.com, a service GitHub retired, and the parameters after
+  # it were HTML-escaped in a URL that never passes through HTML — so the
+  # request carried a parameter named `amp;r`, `s` twice, and a fallback that
+  # no longer resolves. Nothing outside gravatar.com is fetched now, and the
+  # image policy already allows that host.
   def avatar(size = 24)
-    "https://www.gravatar.com/avatar/#{gravatar_hash}?s=#{size}&d=https%3A%2F%2Fidenticons.github.com%2F#{gravatar_hash}.png&amp;r=x&amp;s=#{size}"
+    "https://www.gravatar.com/avatar/#{gravatar_hash}?s=#{size}&d=identicon&r=x"
   end
 
   # override devise trackable to not save on every single request

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,4 +7,27 @@ class UserTest < ActiveSupport::TestCase
     user = User.new(password: "foofoo", password_confirmation: "foofoo", email: "foo @ bar .cccom")
     assert_not user.valid?
   end
+
+  # The avatar is an URL, not markup: an escaped `&` in it names a parameter
+  # `amp;r` instead of `r`, and the fallback it used to carry pointed at a
+  # host GitHub retired, so the picture never arrived.
+  describe "avatar" do
+    let(:user) { users :data }
+
+    it "asks gravatar for the size it was given" do
+      assert_includes user.avatar(64), "s=64"
+    end
+
+    it "leaves the fallback to gravatar rather than a third host" do
+      url = user.avatar
+
+      assert_includes url, "d=identicon"
+      assert_not_includes url, "identicons.github.com"
+    end
+
+    it "separates the parameters with plain ampersands" do
+      assert_not_includes user.avatar, "&amp;"
+      assert_equal 1, user.avatar.scan("s=").size
+    end
+  end
 end


### PR DESCRIPTION
In der Konsole aufgefallen, gilt für beide Frontends:

```
Loading the image 'https://identicons.github.com/4259e4bc….png' violates
the following Content Security Policy directive: "img-src 'self' …"
```

`User#avatar` baute die URL so:

```ruby
"https://www.gravatar.com/avatar/#{gravatar_hash}?s=#{size}&d=https%3A%2F%2Fidenticons.github.com%2F#{gravatar_hash}.png&amp;r=x&amp;s=#{size}"
```

Drei Sachen darin:

1. Der Fallback zeigt auf **identicons.github.com** — ein Dienst, den GitHub abgeschaltet hat. Wer kein Gravatar hat, bekam also gar kein Bild.
2. Selbst wenn er noch liefe, steht der Host nicht in `img_src`, deshalb der CSP-Verstoß.
3. Die `&amp;` sind HTML-Escapes in einer URL, die nie durch HTML läuft. Der Request fragt damit nach einem Parameter `amp;r` statt `r`, und `s` steht doppelt drin.

`d=identicon` lässt Gravatar den Platzhalter selbst zeichnen. Damit bleibt jeder Request auf `www.gravatar.com`, dem einzigen Host, den die Policy dafür ohnehin erlaubt — die CSP muss also nicht angefasst werden.

🤖