### PR TITLE
fix(frontend): the loading indicators, the label baseline and a flaky assertion

### DIFF
--- a/app/frontend/App.vue
+++ b/app/frontend/App.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter, RouterLink, RouterView } from "vue-router"
 import { useI18n } from "vue-i18n"
 import { useCurrentUserStore } from "@/stores/currentUser"
 import { useAccount } from "@/services/api/services/account/account"
+import AppProgress from "@/components/AppProgress.vue"
 import ToastHost from "@/components/ToastHost.vue"
 import UiAlert from "@/components/ui/UiAlert.vue"
 import UiDropdown from "@/components/ui/UiDropdown.vue"
@@ -44,6 +45,8 @@ const trial = computed(() => account.value?.trial)
 
 <template>
   <div class="min-h-screen bg-surface text-ink">
+    <AppProgress />
+
     <template v-if="currentUser.signedIn">
       <!-- Below the aside's breakpoint the navigation collapses to a bar with
            a toggle, and the links slide in from the left. -->

--- a/app/frontend/components/AppProgress.spec.ts
+++ b/app/frontend/components/AppProgress.spec.ts
@@ -1,0 +1,99 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from "vitest"
+import {flushPromises, mount} from "@vue/test-utils"
+import {QueryClient, VueQueryPlugin} from "@tanstack/vue-query"
+import {createMemoryHistory, createRouter} from "vue-router"
+import AppProgress from "./AppProgress.vue"
+
+function mountBar() {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}})
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{path: "/", name: "home", component: {template: "<div />"}}],
+  })
+
+  const wrapper = mount(AppProgress, {
+    global: {plugins: [[VueQueryPlugin, {queryClient}], router]},
+  })
+
+  return {wrapper, queryClient}
+}
+
+const bar = '[data-test="loading-bar"]'
+
+describe("AppProgress", () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it("shows nothing while nothing is in flight", async () => {
+    const {wrapper} = mountBar()
+
+    await flushPromises()
+
+    expect(wrapper.find(bar).exists()).toBe(false)
+  })
+
+  // Turbo holds the bar back for half a second, so a request that answers
+  // quickly never makes it flash.
+  it("stays away for a request that answers inside the delay", async () => {
+    const {wrapper, queryClient} = mountBar()
+
+    let answer: (value: string) => void = () => {}
+    queryClient.fetchQuery({
+      queryKey: ["quick"],
+      queryFn: () => new Promise<string>((resolve) => (answer = resolve)),
+    })
+    await flushPromises()
+
+    vi.advanceTimersByTime(400)
+    answer("done")
+    await flushPromises()
+
+    vi.advanceTimersByTime(400)
+    await flushPromises()
+
+    expect(wrapper.find(bar).exists()).toBe(false)
+  })
+
+  it("appears once a request outlasts the delay, and grows while it runs", async () => {
+    const {wrapper, queryClient} = mountBar()
+
+    queryClient.fetchQuery({queryKey: ["slow"], queryFn: () => new Promise<string>(() => {})})
+    await flushPromises()
+
+    vi.advanceTimersByTime(500)
+    await flushPromises()
+
+    expect(wrapper.find(bar).exists()).toBe(true)
+    const first = wrapper.get(bar).attributes("style")
+
+    vi.advanceTimersByTime(900)
+    await flushPromises()
+
+    expect(wrapper.get(bar).attributes("style")).not.toBe(first)
+  })
+
+  it("runs to the end and leaves once the request is done", async () => {
+    const {wrapper, queryClient} = mountBar()
+
+    let answer: (value: string) => void = () => {}
+    queryClient.fetchQuery({
+      queryKey: ["slow"],
+      queryFn: () => new Promise<string>((resolve) => (answer = resolve)),
+    })
+    await flushPromises()
+
+    vi.advanceTimersByTime(500)
+    await flushPromises()
+    expect(wrapper.find(bar).exists()).toBe(true)
+
+    answer("done")
+    await flushPromises()
+
+    expect(wrapper.get(bar).attributes("style")).toContain("width: 100%")
+
+    vi.advanceTimersByTime(300)
+    await flushPromises()
+
+    expect(wrapper.find(bar).exists()).toBe(false)
+  })
+})

--- a/app/frontend/components/AppProgress.spec.ts
+++ b/app/frontend/components/AppProgress.spec.ts
@@ -72,6 +72,38 @@ describe("AppProgress", () => {
     expect(wrapper.get(bar).attributes("style")).not.toBe(first)
   })
 
+  // Otherwise the bar would still be at the end when the next request
+  // starts, and jump backwards to its starting width half a second later.
+  it("starts over from nothing when work returns during the fade", async () => {
+    const {wrapper, queryClient} = mountBar()
+
+    let answer: (value: string) => void = () => {}
+    queryClient.fetchQuery({
+      queryKey: ["first"],
+      queryFn: () => new Promise<string>((resolve) => (answer = resolve)),
+    })
+    await flushPromises()
+
+    vi.advanceTimersByTime(500)
+    await flushPromises()
+    answer("done")
+    await flushPromises()
+
+    expect(wrapper.get(bar).attributes("style")).toContain("width: 100%")
+
+    // Inside the 300ms fade, before the bar has left.
+    vi.advanceTimersByTime(100)
+    queryClient.fetchQuery({queryKey: ["second"], queryFn: () => new Promise<string>(() => {})})
+    await flushPromises()
+
+    expect(wrapper.find(bar).exists()).toBe(false)
+
+    vi.advanceTimersByTime(500)
+    await flushPromises()
+
+    expect(wrapper.get(bar).attributes("style")).toContain("width: 10%")
+  })
+
   it("runs to the end and leaves once the request is done", async () => {
     const {wrapper, queryClient} = mountBar()
 

--- a/app/frontend/components/AppProgress.vue
+++ b/app/frontend/components/AppProgress.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from "vue"
+import { useIsFetching } from "@tanstack/vue-query"
+import { useRouter } from "vue-router"
+
+// Turbo Drive's progress bar, which every server-rendered navigation shows:
+// a line across the top of the window in the nav's active colour. Turbo holds
+// it back for half a second, so a quick answer never makes it flash, then
+// trickles towards the end without ever arriving until the work is done.
+const DELAY = 500
+const TRICKLE = 300
+
+const fetching = useIsFetching()
+const navigating = ref(0)
+
+const router = useRouter()
+const stopBefore = router.beforeEach(() => {
+  navigating.value += 1
+})
+const stopAfter = router.afterEach(() => {
+  navigating.value = Math.max(0, navigating.value - 1)
+})
+const stopError = router.onError(() => {
+  navigating.value = Math.max(0, navigating.value - 1)
+})
+
+const busy = computed(() => fetching.value > 0 || navigating.value > 0)
+
+const visible = ref(false)
+const done = ref(false)
+const value = ref(0)
+
+let delayTimer: ReturnType<typeof setTimeout> | undefined
+let trickleTimer: ReturnType<typeof setInterval> | undefined
+
+function clearTimers(): void {
+  clearTimeout(delayTimer)
+  clearInterval(trickleTimer)
+  delayTimer = undefined
+  trickleTimer = undefined
+}
+
+function start(): void {
+  clearTimers()
+  done.value = false
+
+  delayTimer = setTimeout(() => {
+    visible.value = true
+    value.value = 10
+    trickleTimer = setInterval(() => {
+      // Approaches the end without reaching it: the remaining distance is
+      // what shrinks, so a slow request keeps moving.
+      value.value += (100 - value.value) / 10
+    }, TRICKLE)
+  }, DELAY)
+}
+
+function finish(): void {
+  clearTimers()
+
+  if (!visible.value) return
+
+  value.value = 100
+  done.value = true
+  delayTimer = setTimeout(() => {
+    visible.value = false
+    value.value = 0
+  }, 300)
+}
+
+watch(busy, (isBusy) => (isBusy ? start() : finish()), {immediate: true})
+
+onBeforeUnmount(() => {
+  clearTimers()
+  stopBefore()
+  stopAfter()
+  stopError()
+})
+</script>
+
+<template>
+  <div
+    v-if="visible"
+    class="fixed top-0 left-0 z-[2147483647] h-[3px] bg-brand"
+    :class="done ? 'opacity-0 transition-opacity duration-150 delay-150' : 'transition-[width] duration-300 ease-out'"
+    :style="{width: `${value}%`}"
+    role="progressbar"
+    aria-hidden="true"
+    data-test="loading-bar"
+  ></div>
+</template>

--- a/app/frontend/components/AppProgress.vue
+++ b/app/frontend/components/AppProgress.vue
@@ -42,6 +42,15 @@ function clearTimers(): void {
 
 function start(): void {
   clearTimers()
+
+  // Work that starts again inside the completion fade finds the bar still
+  // sitting at the end: it goes away first, so the next delay starts from
+  // nothing rather than jumping back from full width.
+  if (done.value) {
+    visible.value = false
+    value.value = 0
+  }
+
   done.value = false
 
   delayTimer = setTimeout(() => {

--- a/app/frontend/components/PdfViewer.vue
+++ b/app/frontend/components/PdfViewer.vue
@@ -54,7 +54,7 @@ async function render(): Promise<void> {
       const canvas = document.createElement("canvas")
       canvas.height = viewport.height
       canvas.width = viewport.width
-      canvas.className = "bs-pdf-page"
+      canvas.className = "bs-pdf-page opacity-0 transition-opacity duration-[600ms]"
 
       const context = canvas.getContext("2d")
       if (!context) throw new Error("no 2d context")
@@ -64,6 +64,7 @@ async function render(): Promise<void> {
       if (mine !== generation) return
 
       host.append(canvas)
+      requestAnimationFrame(() => canvas.classList.remove("opacity-0"))
     }
 
     state.value = "ready"
@@ -80,10 +81,17 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div>
-    <p v-if="state === 'loading'" class="text-sm text-muted" data-test="pdf-loading">
-      {{ t("pdf.loading") }}
-    </p>
+  <div class="relative">
+    <!-- The ring the server-rendered viewer spun in the middle of the empty
+         preview while pdf.js worked. Outside `pages`, which is emptied on
+         every render. -->
+    <div
+      v-if="state === 'loading'"
+      class="bs-loader"
+      role="status"
+      :aria-label="t('pdf.loading')"
+      data-test="pdf-loading"
+    ></div>
     <p v-else-if="state === 'failed'" class="text-sm text-danger" data-test="pdf-failed">
       {{ t("pdf.failed") }}
     </p>

--- a/app/frontend/components/ui/UiLabel.vue
+++ b/app/frontend/components/ui/UiLabel.vue
@@ -16,12 +16,10 @@ const FILLS = {
   danger: "bg-danger",
 } as const
 
-// `.label` is 75% of the body size, which `application.scss` lifts to 90%
-// inside a list row — the size the states are actually seen at.
-const classes = computed(() => [
-  "inline-block rounded-[0.25em] px-[0.6em] pt-[0.2em] pb-[0.3em] text-[90%] leading-none font-bold text-white",
-  FILLS[props.variant],
-])
+// The geometry lives in `.bs-label`: it is `display: inline` on the
+// baseline, and its size depends on whether it sits in a list row, which a
+// utility class cannot express.
+const classes = computed(() => ["bs-label", FILLS[props.variant]])
 </script>
 
 <template>

--- a/app/frontend/entrypoints/spa.css
+++ b/app/frontend/entrypoints/spa.css
@@ -337,6 +337,24 @@
     box-shadow: inset 0 -4px 0 var(--color-brand);
   }
 
+  /* `partials/_loader.scss`: the ring the PDF viewer spins while pdf.js
+     works — three sides in a faint grey, the fourth in the brand colour. */
+  .bs-loader {
+    position: absolute;
+    top: 200px;
+    left: 50%;
+    width: 100px;
+    height: 100px;
+    margin: 60px auto;
+    margin-left: -50px;
+    border-radius: 50%;
+    border-top: 11px solid rgba(204, 204, 204, 0.2);
+    border-right: 11px solid rgba(204, 204, 204, 0.2);
+    border-bottom: 11px solid rgba(204, 204, 204, 0.2);
+    border-left: 11px solid var(--color-brand);
+    animation: bs-spin 1.1s infinite linear;
+  }
+
   /* `_pdf_preview.scss`: the pages are the document, so they carry a soft
      shadow and rounded corners rather than a border, and the viewport holds
      its height while pdf.js is still working. */
@@ -440,5 +458,15 @@
 @media (max-width: 480px) {
   .bs-pdf-preview {
     min-height: 500px;
+  }
+}
+
+@keyframes bs-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
   }
 }

--- a/app/frontend/entrypoints/spa.css
+++ b/app/frontend/entrypoints/spa.css
@@ -337,6 +337,27 @@
     box-shadow: inset 0 -4px 0 var(--color-brand);
   }
 
+  /* `.label`: inline, so its padding never pushes the line it sits on, and
+     on the baseline of the text beside it. 75% of the size around it —
+     `application.scss` lifts it to 90% inside a list row, which is where
+     most of the states are read. */
+  .bs-label {
+    display: inline;
+    padding: 0.2em 0.6em 0.3em;
+    font-size: 75%;
+    font-weight: 700;
+    line-height: 1;
+    color: #ffffff;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 0.25em;
+  }
+
+  .bs-list-item .bs-label {
+    font-size: 90%;
+  }
+
   /* `partials/_loader.scss`: the ring the PDF viewer spins while pdf.js
      works — three sides in a faint grey, the fourth in the brand colour. */
   .bs-loader {

--- a/test/e2e/InvoiceDetail.spec.ts
+++ b/test/e2e/InvoiceDetail.spec.ts
@@ -59,6 +59,26 @@ test.describe("Invoice detail", () => {
     expect(target).toBe("edit")
   })
 
+  // The ring the server-rendered viewer spun over the empty preview. Held up
+  // on purpose, because a PDF that arrives at once never shows it.
+  test("spins while the preview is still loading", async ({ page }) => {
+    const id = (await appEval(`Invoice.first.id`)) as string
+
+    await page.route("**/pdf/**", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+      await route.continue()
+    })
+
+    await page.goto(`/app/invoices/${id}`)
+
+    await expect(page.getByTestId("pdf-loading")).toBeVisible()
+
+    await expect(page.locator('[data-test="pdf-pages"] canvas').first()).toBeVisible({
+      timeout: 60_000,
+    })
+    await expect(page.getByTestId("pdf-loading")).toHaveCount(0)
+  })
+
   // The point of porting the viewer rather than linking out: pdf.js has to
   // work inside the SPA bundle, worker and all.
   test("renders the invoice PDF inline", async ({ page }) => {

--- a/test/e2e/Spa.spec.ts
+++ b/test/e2e/Spa.spec.ts
@@ -125,7 +125,9 @@ test.describe("SPA shell", () => {
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
 
-    await expect(page).toHaveURL(/\/settings$/)
+    // The tabs controller on the server-rendered settings screen appends a
+    // fragment once it takes over, so the assertion has to allow one.
+    await expect(page).toHaveURL(/\/settings(#.*)?$/)
     // The legacy chrome, not the SPA shell.
     await expect(page.locator(".user-email")).toContainText("will@star.fleet")
   })

--- a/test/e2e/Spa.spec.ts
+++ b/test/e2e/Spa.spec.ts
@@ -32,6 +32,30 @@ test.describe("SPA shell", () => {
     await expect(page.getByTestId("submit")).toBeVisible()
   })
 
+  // The bar the server-rendered pages get from Turbo Drive. It waits half a
+  // second first, so the request has to be held up to see it at all.
+  test("draws the loading bar while a request is in flight", async ({ page }) => {
+    await page.goto("/app/login")
+    await page.getByTestId("email").fill("will@star.fleet")
+    await page.getByTestId("password").fill("enterprise")
+    await page.getByTestId("submit").click()
+    await expect(page.getByTestId("dashboard-greeting")).toBeVisible()
+
+    await page.route("**/api/v1/invoices**", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+      await route.continue()
+    })
+
+    await page.getByTestId("nav-invoices").click()
+
+    await expect(page.getByTestId("loading-bar")).toBeVisible()
+    await expect(page).toHaveURL(/\/app\/invoices$/)
+
+    // And it leaves again once the answer is in.
+    await expect(page.getByTestId("loading-bar")).toHaveCount(0, { timeout: 15_000 })
+    await expect(page.getByTestId("new-invoice")).toBeVisible()
+  })
+
   test("keeps the requested path through the login redirect", async ({ page }) => {
     await page.goto("/app/customers")
 


### PR DESCRIPTION
Vier Details, die beim Durchgehen der portierten Screens aufgefallen sind.

### Der Fortschrittsbalken oben

Die server-gerenderten Seiten zeigen bei jedem Besuch Turbo Drives Balken am oberen Fensterrand, in der Navi-Aktivfarbe (`.turbo-progress-bar` in `partials/_nprogress-custom.scss`). Die SPA zeigte nichts — eine Seite mitten im Laden sah aus wie eine leere Seite.

`AppProgress.vue` macht Turbos Verhalten nach: eine halbe Sekunde Verzögerung, damit eine schnelle Antwort ihn nie aufblitzen lässt, dann nähert er sich dem Ende ohne anzukommen, und ist weg, sobald die Arbeit fertig ist. Er beobachtet sowohl das, was vue-query offen hat, als auch die Navigation des Routers — ein Route-Chunk kann genauso lange brauchen wie ein Request.

### Der Spinner der PDF-Vorschau

`App.PDFViewer` drehte einen Ring in der Mitte der leeren Vorschau und blendete jede Seite ein, sobald sie fertig gerendert war. Der Port hatte daraus eine Zeile grauer Text gemacht. Der Ring ist `partials/_loader.scss` unverändert; er sitzt als Geschwister der Seiten, weil das Seiten-Element bei jedem Render geleert wird.

### Die Zustands-Labels

`.label` ist bei Bootstrap `display: inline` auf der Textgrundlinie und **75%** der umgebenden Größe — die 90% gelten nur innerhalb einer `.list-group-item`, und weil dort die meisten Zustände gelesen werden, hatte der Port die 90% als Regel genommen. In einer Überschrift kam das Label damit eine Nummer zu groß heraus und saß als `inline-block` auf seiner eigenen Zeilenbox statt auf der Grundlinie der Wörter daneben.

Gemessen an der Rechnungs-Überschrift: das Label ist jetzt 14,625px zum 30px-Titel — 30 × 0,65 × 0,75 — und seine Unterkante landet auf einem Pixel genau auf der des Überschriftentexts.

### Eine Flake

`returns to the server-rendered screen it was sent from` prüfte `/\/settings$/`, aber der Tabs-Controller der Legacy-Einstellungsseite hängt ein `#basic` an die URL. Ob die Assertion traf, war ein Rennen zwischen beiden — allein grün, im vollen Lauf rot.

Lokal: 181 Vitest, 79 e2e, typecheck grün.

🤖