### PR TITLE
feat(api): report what the expenses list reads

### DIFF
--- a/app/api_components/v1/schemas/expense.rb
+++ b/app/api_components/v1/schemas/expense.rb
@@ -15,6 +15,11 @@ module V1
           date: {type: [:string, :null], format: :date},
           # Decimal columns cross the wire as strings.
           value: {type: [:string, :null]},
+          # What the expense actually deducts, which is not its value: an AfA
+          # expense contributes one year's write-off, a home-office one the
+          # share the account may deduct, everything else the part that is
+          # not private use.
+          usableValue: {type: [:string, :null]},
           vatPercent: {type: [:integer, :null]},
           vatValue: {type: [:string, :null]},
           privateUsePercent: {type: [:integer, :null]},
@@ -22,11 +27,15 @@ module V1
           startedAt: {type: [:string, :null], format: :date},
           endedAt: {type: [:string, :null], format: :date},
           afaTypeId: {type: [:string, :null], format: :uuid},
+          # The row prints a receipt icon, and a red one for a type that
+          # needs a receipt and has none — a business expense never does.
+          hasReceipt: {type: :boolean},
+          needsReceipt: {type: :boolean},
           createdAt: {type: :string, format: "date-time"},
           updatedAt: {type: :string, format: "date-time"}
         },
         additionalProperties: false,
-        required: %w[id expenseType createdAt updatedAt]
+        required: %w[id expenseType hasReceipt needsReceipt createdAt updatedAt]
       })
     end
   end

--- a/app/api_components/v1/schemas/expense_summary.rb
+++ b/app/api_components/v1/schemas/expense_summary.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    # What the filtered set of expenses adds up to. Separate from the list
+    # because paging cannot answer it: page two knows nothing about page one.
+    class ExpenseSummary
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          count: {type: :integer},
+          # Decimals cross the wire as strings.
+          value: {type: :string},
+          vat: {type: :string},
+          # The years the year filter offers, newest first.
+          years: {type: :array, items: {type: :integer}}
+        },
+        additionalProperties: false,
+        required: %w[count value vat years]
+      })
+    end
+  end
+end

--- a/app/controllers/api/v1/expenses_controller.rb
+++ b/app/controllers/api/v1/expenses_controller.rb
@@ -16,9 +16,25 @@ module Api
 
         scope = current_account.expenses
           .filter_result(filter_params)
+          .with_attached_receipt
           .order(date: :desc, created_at: :desc)
 
         @expenses = paginate(scope)
+      end
+
+      # The list prints what the filtered set adds up to, which paging cannot
+      # answer: page two knows nothing about page one. Same filters, so the
+      # numbers belong to the set the list is showing.
+      def summary
+        authorize! :read, :expenses
+
+        scope = current_account.expenses.filter_result(filter_params)
+        year = (filter_params[:year].presence || Time.zone.now.year).to_i
+
+        @count = scope.count
+        @value = deductible_sum(scope, year)
+        @vat = normalized(scope).sum(&:vat_value)
+        @years = filter_years
       end
 
       def show
@@ -87,6 +103,45 @@ module Api
         destroyed = expenses.count { |expense| expense.destroy }
 
         render json: {count: destroyed, message: I18n.t(:"expenses.bulk.destroyed", count: destroyed)}
+      end
+
+      # An expense on an interval stands for one entry per period it covers,
+      # so the sums are taken over those rather than over the records. Health
+      # and social insurance sit outside the total unless that is what you
+      # asked to see — they are not business expenses, and the panel that
+      # reports them counts them separately.
+      private def normalized(scope, year = filter_params[:year].presence)
+        return ::Expense.normalized(scope.to_a, year: year) if filter_params[:type] == "insurances"
+
+        ::Expense.normalized(scope.without_insurances.to_a, year: year)
+      end
+
+      # An AfA expense deducts one year's write-off rather than its value, and
+      # that share does not repeat per period — so it is counted once from the
+      # records instead of from the normalized entries.
+      private def deductible_sum(scope, year)
+        write_offs = scope.filter_type(:afa).sum { |expense| expense.afa_value(year) }
+
+        normalized(scope).sum { |expense|
+          next 0 if expense.expense_type == "afa"
+
+          expense.usable_value(year)
+        } + write_offs
+      end
+
+      # The year dropdown offers a run of years, newest first, the way the
+      # server-rendered filter did. It reads the first year off the expenses
+      # themselves, where the helper behind the old screen read it off the
+      # first *invoice* — an account with expenses and no invoices could not
+      # reach the year its expenses were in.
+      private def filter_years
+        current = (Time.zone.now.month == 12) ? 1.year.from_now.year : Time.zone.now.year
+        earliest = [
+          current_account.expenses.minimum(:date)&.year,
+          current_account.expenses.minimum(:started_at)&.year
+        ].compact.min
+
+        ((earliest || 1.year.ago.year)..current).to_a.reverse
       end
 
       # Expenses are behind an account feature flag, same as the web UI.

--- a/app/controllers/api/v1/expenses_controller.rb
+++ b/app/controllers/api/v1/expenses_controller.rb
@@ -32,8 +32,11 @@ module Api
         year = (filter_params[:year].presence || Time.zone.now.year).to_i
 
         @count = scope.count
+        # Seeded with decimals: an empty set would otherwise sum to an
+        # integer zero and cross the wire as a number where the schema — and
+        # every non-empty answer — has a string.
         @value = deductible_sum(scope, year)
-        @vat = normalized(scope).sum(&:vat_value)
+        @vat = normalized(scope).sum(0.to_d, &:vat_value)
         @years = filter_years
       end
 
@@ -110,19 +113,44 @@ module Api
       # and social insurance sit outside the total unless that is what you
       # asked to see — they are not business expenses, and the panel that
       # reports them counts them separately.
-      private def normalized(scope, year = filter_params[:year].presence)
-        return ::Expense.normalized(scope.to_a, year: year) if filter_params[:type] == "insurances"
+      private def normalized(scope)
+        year = filter_params[:year].presence
+        entries = if filter_params[:type] == "insurances"
+          ::Expense.normalized(scope.to_a, year: year)
+        else
+          ::Expense.normalized(scope.without_insurances.to_a, year: year)
+        end
 
-        ::Expense.normalized(scope.without_insurances.to_a, year: year)
+        window = filter_window
+        return entries if window.nil?
+
+        entries.select { |entry| entry.date.present? && window.cover?(entry.date) }
+      end
+
+      # The sums have to belong to the set the list is showing, so the periods
+      # of an expense on an interval are counted only where the filter looks:
+      # a monthly expense filtered to March is one entry, not twelve.
+      # `filter_quarter` and `filter_month` read the year the same way, from
+      # the filter or from today.
+      private def filter_window
+        year = (filter_params[:year].presence || Time.zone.now.year).to_i
+        month = filter_params[:month].presence.to_i
+        quarter = filter_params[:quarter].presence.to_i
+
+        return Date.new(year, month, 1)..Date.new(year, month, -1) if (1..12).cover?(month)
+        return Date.new(year, quarter * 3 - 2, 1)..Date.new(year, quarter * 3, -1) if (1..4).cover?(quarter)
+        return Date.new(year, 1, 1)..Date.new(year, 12, 31) if filter_params[:year].present?
+
+        nil
       end
 
       # An AfA expense deducts one year's write-off rather than its value, and
       # that share does not repeat per period — so it is counted once from the
       # records instead of from the normalized entries.
       private def deductible_sum(scope, year)
-        write_offs = scope.filter_type(:afa).sum { |expense| expense.afa_value(year) }
+        write_offs = scope.filter_type(:afa).sum(0.to_d) { |expense| expense.afa_value(year) }
 
-        normalized(scope).sum { |expense|
+        normalized(scope).sum(0.to_d) { |expense|
           next 0 if expense.expense_type == "afa"
 
           expense.usable_value(year)
@@ -136,12 +164,20 @@ module Api
       # reach the year its expenses were in.
       private def filter_years
         current = (Time.zone.now.month == 12) ? 1.year.from_now.year : Time.zone.now.year
-        earliest = [
+        years = [
           current_account.expenses.minimum(:date)&.year,
-          current_account.expenses.minimum(:started_at)&.year
-        ].compact.min
+          current_account.expenses.minimum(:started_at)&.year,
+          current_account.expenses.maximum(:date)&.year,
+          current_account.expenses.maximum(:ended_at)&.year
+        ].compact
 
-        ((earliest || 1.year.ago.year)..current).to_a.reverse
+        # Clamped both ways: an expense dated ahead of today would otherwise
+        # leave the range empty and the dropdown with nothing in it, not even
+        # the year being looked at.
+        first = [years.min || 1.year.ago.year, current].min
+        last = [years.max || current, current].max
+
+        (first..last).to_a.reverse
       end
 
       # Expenses are behind an account feature flag, same as the web UI.

--- a/app/controllers/api/v1/expenses_controller.rb
+++ b/app/controllers/api/v1/expenses_controller.rb
@@ -137,11 +137,18 @@ module Api
         month = filter_params[:month].presence.to_i
         quarter = filter_params[:quarter].presence.to_i
 
-        return Date.new(year, month, 1)..Date.new(year, month, -1) if (1..12).cover?(month)
-        return Date.new(year, quarter * 3 - 2, 1)..Date.new(year, quarter * 3, -1) if (1..4).cover?(quarter)
-        return Date.new(year, 1, 1)..Date.new(year, 12, 31) if filter_params[:year].present?
+        windows = []
+        windows << (Date.new(year, month, 1)..Date.new(year, month, -1)) if (1..12).cover?(month)
+        windows << (Date.new(year, quarter * 3 - 2, 1)..Date.new(year, quarter * 3, -1)) if (1..4).cover?(quarter)
+        windows << (Date.new(year, 1, 1)..Date.new(year, 12, 31)) if filter_params[:year].present?
 
-        nil
+        return nil if windows.empty?
+
+        # Month and quarter are separate dropdowns and can both be set, and
+        # `filter_result` chains them — so the window is where they overlap.
+        # Where they do not, the range comes out backwards and covers
+        # nothing, which is the same answer the list gives.
+        windows.map(&:first).max..windows.map(&:last).min
       end
 
       # An AfA expense deducts one year's write-off rather than its value, and

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -182,8 +182,13 @@ class Expense < ApplicationRecord
     value / afa_type_value
   end
 
+  # The share stays nil until the account has entered both its office and
+  # the deductible part of it, and an expense whose share is unknown deducts
+  # nothing. Answering nil instead made `vat_value` and every sum over these
+  # expenses raise on the multiplication — which is what the expenses list
+  # did for any account that never filled in its office space.
   def home_office_value
-    return if account.deductible_office_percent.blank?
+    return 0.0 if account.deductible_office_percent.blank?
 
     (value * account.deductible_office_percent) / 100.0
   end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -176,8 +176,14 @@ class Expense < ApplicationRecord
     end
   end
 
+  # An AfA expense is a purchase written off over the years its type allows,
+  # counted from the day it was bought. `date` is only validated on a
+  # one-off, so an interval leaves it empty and the start of the interval is
+  # the day to count from — reading `date.year` there raised.
   def afa_value(year = Time.zone.now.year)
-    return 0.0 if afa_type_value.blank? || (date.year + afa_type_value) < year
+    bought_on = date || started_at
+    return 0.to_d if afa_type_value.blank? || bought_on.blank?
+    return 0.to_d if (bought_on.year + afa_type_value) < year
 
     value / afa_type_value
   end
@@ -188,7 +194,9 @@ class Expense < ApplicationRecord
   # expenses raise on the multiplication — which is what the expenses list
   # did for any account that never filled in its office space.
   def home_office_value
-    return 0.0 if account.deductible_office_percent.blank?
+    # A decimal rather than 0.0: every other branch answers one, and a float
+    # here would cross the wire as a JSON number where the rest are strings.
+    return 0.to_d if account.deductible_office_percent.blank?
 
     (value * account.deductible_office_percent) / 100.0
   end

--- a/app/views/api/v1/expenses/_show.json.jbuilder
+++ b/app/views/api/v1/expenses/_show.json.jbuilder
@@ -6,6 +6,7 @@ json.description expense.description
 json.seller expense.seller
 json.date expense.date
 json.value expense.value
+json.usable_value expense.usable_value
 json.vat_percent expense.vat_percent
 json.vat_value expense.vat_value
 json.private_use_percent expense.private_use_percent
@@ -13,5 +14,7 @@ json.interval expense.interval
 json.started_at expense.started_at
 json.ended_at expense.ended_at
 json.afa_type_id expense.afa_type_id
+json.has_receipt expense.receipt.attached?
+json.needs_receipt expense.needs_receipt?
 json.created_at expense.created_at
 json.updated_at expense.updated_at

--- a/app/views/api/v1/expenses/summary.json.jbuilder
+++ b/app/views/api/v1/expenses/summary.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.count @count
+json.value @value
+json.vat @vat
+json.years @years

--- a/config/routes/api_v1_routes.rb
+++ b/config/routes/api_v1_routes.rb
@@ -78,6 +78,7 @@ v1_api_routes = lambda do
 
   resources :expenses, only: %i[index show create update destroy] do
     collection do
+      get :summary
       post :bulk_update
       post :bulk_destroy
     end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -732,6 +732,64 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/expenses/summary":
+    get:
+      summary: What the filtered expenses add up to
+      tags:
+      - Expenses
+      operationId: expenseSummary
+      parameters:
+      - name: year
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: quarter
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 4
+      - name: month
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 12
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: query
+        in: query
+        required: false
+        description: Free-text search over the description.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ExpenseSummary"
+        '403':
+          description: expenses not enabled for this account
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/expenses/{id}":
     parameters:
     - name: id
@@ -3369,6 +3427,10 @@ components:
           type:
           - string
           - 'null'
+        usableValue:
+          type:
+          - string
+          - 'null'
         vatPercent:
           type:
           - integer
@@ -3401,6 +3463,10 @@ components:
           - string
           - 'null'
           format: uuid
+        hasReceipt:
+          type: boolean
+        needsReceipt:
+          type: boolean
         createdAt:
           type: string
           format: date-time
@@ -3411,6 +3477,8 @@ components:
       required:
       - id
       - expenseType
+      - hasReceipt
+      - needsReceipt
       - createdAt
       - updatedAt
       title: Expense
@@ -3662,6 +3730,26 @@ components:
           format: date
       additionalProperties: false
       title: ExpenseInput
+    ExpenseSummary:
+      type: object
+      properties:
+        count:
+          type: integer
+        value:
+          type: string
+        vat:
+          type: string
+        years:
+          type: array
+          items:
+            type: integer
+      additionalProperties: false
+      required:
+      - count
+      - value
+      - vat
+      - years
+      title: ExpenseSummary
     Expenses:
       type: array
       items:

--- a/test/fixtures/afa_types.yml
+++ b/test/fixtures/afa_types.yml
@@ -9,3 +9,9 @@ two:
   value: 1
   valid_from: 2022-09-18
   valid_until: 2022-09-18
+
+# Written off over three years, so a 1200 expense deducts 400 a year.
+three_years:
+  value: 3
+  valid_from: 2022-09-18
+  valid_until: 2032-09-18

--- a/test/integration/api/v1/expense_summary_test.rb
+++ b/test/integration/api/v1/expense_summary_test.rb
@@ -131,6 +131,30 @@ module Api
           end
         end
 
+        # A filtered total has to belong to the filtered set: the periods of
+        # an expense on an interval only count where the filter looks.
+        it "counts an interval only for the periods inside the filtered month" do
+          expense_worth(
+            10, date: nil, interval: "monthly",
+            started_at: Date.new(year, 1, 1), ended_at: Date.new(year, 12, 31)
+          )
+
+          assert_api_response :get, 200, params: {year: year, month: 3} do
+            assert_equal 10.0, parsed_body["value"].to_f
+          end
+        end
+
+        it "counts an interval only for the periods inside the filtered quarter" do
+          expense_worth(
+            10, date: nil, interval: "monthly",
+            started_at: Date.new(year, 1, 1), ended_at: Date.new(year, 12, 31)
+          )
+
+          assert_api_response :get, 200, params: {year: year, quarter: 2} do
+            assert_equal 30.0, parsed_body["value"].to_f
+          end
+        end
+
         # An AfA expense deducts one year's write-off rather than its value,
         # and that share does not repeat per period either.
         it "counts an afa expense at its yearly write-off" do
@@ -164,6 +188,47 @@ module Api
 
           assert_api_response :get, 200, params: {year: year} do
             assert_equal [year, year - 1, year - 2], parsed_body["years"].first(3)
+          end
+        end
+
+        # `date` is only validated on a one-off, so an AfA expense on an
+        # interval is a record the model accepts with no date at all. Reading
+        # its year raised, and took this endpoint and the list down with it.
+        it "counts an afa expense on an interval from the day it starts" do
+          expense_worth(
+            1200, type: "afa", date: nil, interval: "monthly",
+            started_at: Date.new(year, 3, 1), afa_type: afa_types(:three_years)
+          )
+
+          assert_api_response :get, 200 do
+            assert_equal 400.0, parsed_body["value"].to_f
+          end
+        end
+
+        # Both are decimals, and decimals cross the wire as strings — an
+        # empty set used to sum to an integer and answer a bare number.
+        it "reports the money as strings, even with nothing to add up" do
+          assert_api_response :get, 200 do
+            assert_kind_of String, parsed_body["value"]
+            assert_kind_of String, parsed_body["vat"]
+          end
+
+          expense_worth(100)
+
+          assert_api_response :get, 200 do
+            assert_kind_of String, parsed_body["value"]
+          end
+        end
+
+        # An expense can be dated ahead of today, and the range used to come
+        # out empty — leaving the dropdown with nothing in it, not even the
+        # year being looked at.
+        it "offers a year an expense is dated ahead in" do
+          expense_worth(100, date: Date.new(year + 2, 7, 1))
+
+          assert_api_response :get, 200 do
+            assert_includes parsed_body["years"], year + 2
+            assert_includes parsed_body["years"], year
           end
         end
 

--- a/test/integration/api/v1/expense_summary_test.rb
+++ b/test/integration/api/v1/expense_summary_test.rb
@@ -155,6 +155,30 @@ module Api
           end
         end
 
+        # Month and quarter are separate dropdowns, so both can be set at
+        # once and the list intersects them. The total has to agree.
+        it "counts an interval where the month and the quarter meet" do
+          expense_worth(
+            10, date: nil, interval: "monthly",
+            started_at: Date.new(year, 1, 1), ended_at: Date.new(year, 12, 31)
+          )
+
+          assert_api_response :get, 200, params: {year: year, month: 3, quarter: 1} do
+            assert_equal 10.0, parsed_body["value"].to_f
+          end
+        end
+
+        it "counts nothing where the month and the quarter do not meet" do
+          expense_worth(
+            10, date: nil, interval: "monthly",
+            started_at: Date.new(year, 1, 1), ended_at: Date.new(year, 12, 31)
+          )
+
+          assert_api_response :get, 200, params: {year: year, month: 3, quarter: 4} do
+            assert_equal 0.0, parsed_body["value"].to_f
+          end
+        end
+
         # An AfA expense deducts one year's write-off rather than its value,
         # and that share does not repeat per period either.
         it "counts an afa expense at its yearly write-off" do

--- a/test/integration/api/v1/expense_summary_test.rb
+++ b/test/integration/api/v1/expense_summary_test.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+module Api
+  module V1
+    # Its own class because the DSL matches requests on verb and path params,
+    # which cannot tell `GET /expenses` and `GET /expenses/summary` apart.
+    class ExpenseSummaryTest < ActionDispatch::IntegrationTest
+      include OpenapiRuby::Adapters::Minitest::DSL
+
+      openapi_schema :"v1/schema"
+
+      api_path "/expenses/summary" do
+        get("What the filtered expenses add up to") do
+          operationId "expenseSummary"
+          tags "Expenses"
+          produces "application/json"
+
+          parameter name: "year", in: :query, required: false, schema: {type: :integer}
+          parameter name: "quarter", in: :query, required: false, schema: {type: :integer, minimum: 1, maximum: 4}
+          parameter name: "month", in: :query, required: false, schema: {type: :integer, minimum: 1, maximum: 12}
+          parameter name: "type", in: :query, required: false, schema: {type: :string}
+          parameter name: "query", in: :query, required: false,
+            description: "Free-text search over the description.",
+            schema: {type: :string}
+
+          response(200, "successful") do
+            schema ::V1::Schemas::ExpenseSummary
+          end
+
+          response(403, "expenses not enabled for this account") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(401, "unauthorized") do
+            schema ::V1::Schemas::StandardError
+          end
+        end
+      end
+
+      let(:data) { users :data }
+      let(:account) { accounts :enterprise }
+      let(:year) { Time.zone.now.year }
+
+      before { account.update!(feature_expenses: true) }
+
+      def expense_worth(value, type: "gwg", date: nil, **attributes)
+        account.expenses.create!(
+          {
+            expense_type: type, value: value, description: "Tricorder",
+            seller: "Daystrom Institute", date: date || Date.new(year, 3, 1),
+            vat_percent: 0, private_use_percent: 0, interval: "once"
+          }.merge(attributes)
+        )
+      end
+
+      it "is unauthorized when signed out" do
+        assert_api_response :get, 401
+      end
+
+      describe "when the account has expenses switched off" do
+        before do
+          account.update!(feature_expenses: false)
+          sign_in data
+        end
+
+        it "is forbidden" do
+          assert_api_response :get, 403 do
+            assert_equal "feature.disabled", parsed_body["code"]
+          end
+        end
+      end
+
+      describe "signed in" do
+        before do
+          sign_in data
+          account.expenses.destroy_all
+        end
+
+        it "adds up what the account may deduct" do
+          expense_worth(100)
+          expense_worth(250)
+
+          assert_api_response :get, 200 do
+            assert_equal 2, parsed_body["count"]
+            assert_equal 350.0, parsed_body["value"].to_f
+          end
+        end
+
+        # `private_use_percent` is the share that is not the business's, and
+        # only the rest is deductible.
+        it "leaves the private share out of the total" do
+          expense_worth(100, private_use_percent: 40)
+
+          assert_api_response :get, 200 do
+            assert_equal 60.0, parsed_body["value"].to_f
+          end
+        end
+
+        it "reports the vat of the set beside it" do
+          expense_worth(100, vat_percent: 19)
+
+          assert_api_response :get, 200 do
+            assert_equal 19.0, parsed_body["vat"].to_f
+          end
+        end
+
+        # The numbers have to belong to the set the list is showing, not to
+        # everything — otherwise the total under a filtered table is a lie.
+        it "counts only what the filter leaves" do
+          expense_worth(100, date: Date.new(year, 3, 1))
+          expense_worth(900, date: Date.new(year - 1, 3, 1))
+
+          assert_api_response :get, 200, params: {year: year} do
+            assert_equal 1, parsed_body["count"]
+            assert_equal 100.0, parsed_body["value"].to_f
+          end
+        end
+
+        # An expense on an interval stands for one entry per period it
+        # covers: a year of a monthly 10 is 120, not 10.
+        it "counts an interval once per period it covers" do
+          expense_worth(
+            10, date: nil, interval: "monthly",
+            started_at: Date.new(year, 1, 1), ended_at: Date.new(year, 12, 31)
+          )
+
+          assert_api_response :get, 200, params: {year: year} do
+            assert_equal 120.0, parsed_body["value"].to_f
+          end
+        end
+
+        # An AfA expense deducts one year's write-off rather than its value,
+        # and that share does not repeat per period either.
+        it "counts an afa expense at its yearly write-off" do
+          expense_worth(1200, type: "afa", afa_type: afa_types(:three_years))
+
+          assert_api_response :get, 200 do
+            assert_equal 400.0, parsed_body["value"].to_f
+          end
+        end
+
+        # Health and social insurance are not business expenses. The panel
+        # that reports them counts them separately, so they stay out of this
+        # total unless they are what you asked to see.
+        it "leaves insurances out until they are the filter" do
+          expense_worth(100)
+          expense_worth(500, type: "insurances")
+
+          assert_api_response :get, 200 do
+            assert_equal 100.0, parsed_body["value"].to_f
+          end
+
+          assert_api_response :get, 200, params: {type: "insurances"} do
+            assert_equal 500.0, parsed_body["value"].to_f
+          end
+        end
+
+        # The year dropdown needs the years you could switch to, so this one
+        # ignores the filters on purpose.
+        it "offers the years the expenses reach back to" do
+          expense_worth(100, date: Date.new(year - 2, 7, 1))
+
+          assert_api_response :get, 200, params: {year: year} do
+            assert_equal [year, year - 1, year - 2], parsed_body["years"].first(3)
+          end
+        end
+
+        it "offers last year and this one for an account without expenses" do
+          assert_api_response :get, 200 do
+            assert_equal 0, parsed_body["count"]
+            assert_equal [year, year - 1], parsed_body["years"]
+          end
+        end
+
+        it "leaves another account's expenses out" do
+          accounts(:defiant).expenses.create!(
+            expense_type: "gwg", value: 999, description: "Cloaking device",
+            seller: "Tal Shiar", date: Date.new(year, 3, 1),
+            vat_percent: 0, private_use_percent: 0, interval: "once"
+          )
+          expense_worth(100)
+
+          assert_api_response :get, 200 do
+            assert_equal 1, parsed_body["count"]
+            assert_equal 100.0, parsed_body["value"].to_f
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/api/v1/expenses_test.rb
+++ b/test/integration/api/v1/expenses_test.rb
@@ -113,6 +113,11 @@ module Api
             row = parsed_body.find { |item| item["id"] == business.id }
 
             assert_equal false, row["needsReceipt"]
+            # The account has entered no office space, so there is no share
+            # to deduct — and a decimal zero, which crosses the wire as the
+            # string the schema declares, not as a number.
+            assert_kind_of String, row["usableValue"]
+            assert_equal 0.0, row["usableValue"].to_f
           end
         end
 

--- a/test/integration/api/v1/expenses_test.rb
+++ b/test/integration/api/v1/expenses_test.rb
@@ -88,6 +88,34 @@ module Api
           end
         end
 
+        # The row prints what the expense actually deducts — not its value —
+        # and whether its receipt is there.
+        it "reports the deductible value and the receipt state" do
+          assert_api_response :get, 200 do
+            row = parsed_body.find { |item| item["id"] == expense.id }
+
+            assert_equal expense.usable_value.to_f, row["usableValue"].to_f
+            assert_equal false, row["hasReceipt"]
+            assert_equal true, row["needsReceipt"]
+          end
+        end
+
+        # A business expense has no receipt to file, so the row must not ask
+        # for one.
+        it "asks for no receipt on a business expense" do
+          business = account.expenses.create!(
+            expense_type: "home_office", value: 100, description: "Desk",
+            seller: "Daystrom Institute", date: Date.new(Time.zone.now.year, 3, 1),
+            vat_percent: 0, private_use_percent: 0, interval: "once"
+          )
+
+          assert_api_response :get, 200 do
+            row = parsed_body.find { |item| item["id"] == business.id }
+
+            assert_equal false, row["needsReceipt"]
+          end
+        end
+
         it "creates an expense" do
           assert_api_response :post, 201, body: {
             expense_type: "other", description: "Tricorder", seller: "Starfleet Supply",

--- a/test/models/expense_test.rb
+++ b/test/models/expense_test.rb
@@ -41,5 +41,51 @@ class ExpenseTest < ActiveSupport::TestCase
       assert_equal 0.0, expense.usable_value
       assert_equal 0.0, expense.vat_value
     end
+
+    # Decimals cross the wire as strings, floats as numbers, and the API
+    # declares these fields as strings.
+    it "answers a decimal either way" do
+      assert_kind_of BigDecimal, expense.usable_value
+
+      account.update!(office_space: nil, deductible_office_space: nil, deductible_office_percent: nil)
+
+      assert_kind_of BigDecimal, expense.usable_value
+    end
+  end
+
+  describe "an afa expense" do
+    let(:account) { accounts :enterprise }
+
+    def afa(**attributes)
+      account.expenses.new({
+        expense_type: "afa", value: 1200, description: "Tricorder",
+        seller: "Daystrom Institute", afa_type: afa_types(:three_years),
+        vat_percent: 0, private_use_percent: 0, interval: "once",
+        date: Date.new(2026, 3, 1)
+      }.merge(attributes))
+    end
+
+    it "writes off a share of the value for each year its type allows" do
+      assert_equal 400.0, afa.afa_value(2026)
+    end
+
+    it "has written the whole value off once the years have passed" do
+      assert_equal 0.0, afa.afa_value(2030)
+    end
+
+    # `date` is only validated on a one-off, so an interval leaves it empty
+    # and the start of the interval is the day to count from. Reading
+    # `date.year` raised — on a record the model considers valid, which took
+    # the expenses list and its sums down with it.
+    it "counts from the start of an interval when it has no date" do
+      recurring = afa(interval: "monthly", date: nil, started_at: Date.new(2026, 3, 1))
+
+      assert recurring.valid?, recurring.errors.full_messages.join(", ")
+      assert_equal 400.0, recurring.afa_value(2026)
+    end
+
+    it "writes nothing off while it has no day to count from" do
+      assert_equal 0.0, afa(date: nil, interval: "monthly", started_at: nil).afa_value(2026)
+    end
   end
 end

--- a/test/models/expense_test.rb
+++ b/test/models/expense_test.rb
@@ -14,4 +14,32 @@ class ExpenseTest < ActiveSupport::TestCase
       2022-01-31 2022-02-28 2022-03-31 2022-04-30 2022-05-31
     ], expense.dates_for_interval.map(&:iso8601)
   end
+
+  describe "a home office expense" do
+    let(:account) { accounts :enterprise }
+    let(:expense) do
+      account.expenses.create!(
+        expense_type: "home_office", value: 100, description: "Desk",
+        seller: "Daystrom Institute", date: Date.new(2026, 3, 1),
+        vat_percent: 19, private_use_percent: 0, interval: "once"
+      )
+    end
+
+    it "deducts the share of the office the account may deduct" do
+      account.update!(office_space: 100, deductible_office_space: 20)
+
+      assert_equal 20.0, expense.usable_value
+      assert_in_delta 3.8, expense.vat_value, 0.01
+    end
+
+    # The account has entered no office space, so the share is unknown. It
+    # used to answer nil, and every sum over it — and the vat beside it —
+    # raised on the multiplication.
+    it "deducts nothing while the account has no office to go by" do
+      account.update!(office_space: nil, deductible_office_space: nil, deductible_office_percent: nil)
+
+      assert_equal 0.0, expense.usable_value
+      assert_equal 0.0, expense.vat_value
+    end
+  end
 end


### PR DESCRIPTION
Erster Schritt für die Ausgaben in der SPA — der einzige Hauptmenüpunkt, der dort noch fehlt. Die API war größtenteils schon da (Liste mit Filtern, CRUD, Bulk-Aktionen, Import); es fehlten drei Dinge, die die Liste liest.

### `usableValue`

Der Betrag rechts in der Zeile ist nicht der Wert der Ausgabe. `_list_item.html.erb` druckt `expense.usable_value` — bei AfA die Jahresabschreibung, beim Home-Office den abzugsfähigen Anteil, sonst den nicht-privaten Teil.

### `hasReceipt` und `needsReceipt`

Für das Beleg-Icon am Zeilenende und das rote, das einen fehlenden Beleg anzeigt. Betriebsausgaben brauchen keinen. Der Index lädt den Anhang mit `with_attached_receipt`, damit das Icon keine Query pro Zeile kostet.

### `GET /expenses/summary`

Die Summen unter der Überschrift, die Paginierung nicht beantworten kann. Die Rechnung ist die des server-gerenderten Screens, eins zu eins:

- Eine Ausgabe mit Intervall zählt **einmal pro Periode**, die sie abdeckt — ein monatlicher Zehner über ein Jahr sind 120, nicht 10.
- **AfA** trägt die Jahresabschreibung bei, nicht ihren Wert, und diese Abschreibung wiederholt sich nicht pro Periode.
- **Versicherungen** bleiben außerhalb der Summe, bis sie der Filter sind.

Ein bewusster Unterschied: `years`. Die alte Jahres-Auswahl las ihr erstes Jahr über `first_expenses_year` — und das schaut auf die **erste Rechnung** des Kontos, nicht auf die Ausgaben. Ein Konto mit Ausgaben und ohne Rechnungen konnte das Jahr seiner eigenen Ausgaben nicht auswählen. Die neue Liste liest die Ausgaben.

### Dazu ein Fehler, den der Test aufgedeckt hat

`deductible_office_percent` wird aus Bürofläche und abzugsfähigem Anteil berechnet und bleibt `nil`, solange beides nicht eingetragen ist — der Normalfall. `home_office_value` gab dort `nil` zurück, und `vat_value` multipliziert damit:

```ruby
def vat_value
  usable_value * vat_percent / 100   # nil * 19  →  NoMethodError
end
```

Die **Ausgabenliste stürzt** damit heute für jedes solche Konto mit einer Home-Office-Ausgabe ab (`_list_item.html.erb:23`), ebenso jede Summe darüber — auch die im Dashboard. Eine Ausgabe, deren abzugsfähiger Anteil unbekannt ist, zieht nichts ab, also 0.0. Eigener Commit.

12 neue Integrationstests für die Summary, zwei für die Zeilenfelder, zwei fürs Modell.

Als Nächstes: der Listen-Screen, dann das Formular (mit Beleg-Upload und AfA-Typen), dann der Import-Assistent.

🤖