### PR TITLE
fix(routes): keep the query string when a path hands over to the SPA

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,8 +38,15 @@ Rails.application.routes.draw do
   # link Devise sent last month is already sitting in someone's inbox and has
   # to keep working — including for a locked account, which has no other way
   # back in. The token travels in the query string, so it comes along.
-  spa_screen = ->(path) do
-    redirect { |_params, request| [path, request.query_string.presence].compact.join("?") }
+  #
+  # Every path below is built through this, because `redirect("/app/…")`
+  # drops the query string: a bookmarked filtered list, or a link that
+  # preselects a project for a new invoice, would arrive bare.
+  spa_screen = ->(pattern) do
+    redirect do |params, request|
+      path = pattern % params.to_h.symbolize_keys
+      [path, request.query_string.presence].compact.join("?")
+    end
   end
 
   get "/users/confirmation", to: spa_screen.call("/app/confirmation")
@@ -61,7 +68,7 @@ Rails.application.routes.draw do
     # The SPA renders the login. The name stays so the handful of
     # `new_user_session_path` callers keep working, and a bookmark on /signin
     # still lands somewhere sensible.
-    get "signin" => redirect("/app/login"), :as => :new_user_session
+    get "signin" => spa_screen.call("/app/login"), :as => :new_user_session
     delete "signout" => "sessions#destroy", :as => :destroy_user_session
   end
 
@@ -81,17 +88,13 @@ Rails.application.routes.draw do
   # navigation links `invoices_path`, and so do the redirects after charging
   # or paying an invoice. The query travels with it, so a filtered, sorted
   # link keeps working.
-  get "invoices", to: redirect { |_params, request|
-    ["/app/invoices", request.query_string.presence].compact.join("?")
-  }, as: :invoices
+  get "invoices", to: spa_screen.call("/app/invoices"), as: :invoices
 
   # The SPA owns the form too (phase B6). Declared before the resource so
   # `/invoices/new` reaches the SPA rather than the ERB screen, and named to
   # keep `new_invoice_path` — the dashboard and the project page link it.
-  get "invoices/new", to: redirect { |_params, request|
-    ["/app/invoices/new", request.query_string.presence].compact.join("?")
-  }, as: :new_invoice
-  get "invoices/:id/edit", to: redirect("/app/invoices/%{id}/edit"), as: :edit_invoice
+  get "invoices/new", to: spa_screen.call("/app/invoices/new"), as: :new_invoice
+  get "invoices/:id/edit", to: spa_screen.call("/app/invoices/%{id}/edit"), as: :edit_invoice
 
   # What is left of the server-rendered invoice: the PDFs, which the plan keeps
   # server-rendered on purpose. Charging, paying, mailing, creating, updating
@@ -107,20 +110,16 @@ Rails.application.routes.draw do
   # longer carries `update` and `destroy` to provide `invoice_path` — the
   # dashboard and project panels link it. Declared after the resource so its
   # `:id` cannot swallow the member routes above.
-  get "invoices/:id", to: redirect("/app/invoices/%{id}"), as: :invoice
+  get "invoices/:id", to: spa_screen.call("/app/invoices/%{id}"), as: :invoice
 
   # The SPA owns the offer screens (phase B7). The list keeps its query — the
   # main navigation links `offers_path` — and the name comes back here now
   # that the resource no longer carries `create` to provide it.
-  get "offers", to: redirect { |_params, request|
-    ["/app/offers", request.query_string.presence].compact.join("?")
-  }, as: :offers
+  get "offers", to: spa_screen.call("/app/offers"), as: :offers
 
   # `?project_id=` survives: the project page links a new offer for itself.
-  get "offers/new", to: redirect { |_params, request|
-    ["/app/offers/new", request.query_string.presence].compact.join("?")
-  }, as: :new_offer
-  get "offers/:id/edit", to: redirect("/app/offers/%{id}/edit"), as: :edit_offer
+  get "offers/new", to: spa_screen.call("/app/offers/new"), as: :new_offer
+  get "offers/:id/edit", to: spa_screen.call("/app/offers/%{id}/edit"), as: :edit_offer
 
   # What is left of the server-rendered offer: the PDF, which the plan keeps
   # server-rendered on purpose. Creating, updating, deleting and the state
@@ -133,13 +132,11 @@ Rails.application.routes.draw do
 
   # Named because the dashboard's offer panel links it. Declared after the
   # resource so its `:id` cannot swallow the member routes above.
-  get "offers/:id", to: redirect("/app/offers/%{id}"), as: :offer
+  get "offers/:id", to: spa_screen.call("/app/offers/%{id}"), as: :offer
 
   # The SPA owns the timesheet (phase B4). The name stays: the main
   # navigation links `timesheet_path`.
-  get "timesheet", to: redirect { |_params, request|
-    ["/app/timesheet", request.query_string.presence].compact.join("?")
-  }, as: :timesheet
+  get "timesheet", to: spa_screen.call("/app/timesheet"), as: :timesheet
 
   resource :template, only: [] do
     template "blank"
@@ -152,16 +149,16 @@ Rails.application.routes.draw do
   # The SPA owns the customer screens (phase B3). The name stays because the
   # project list still links here, and a bookmark on the old path should land
   # on the new screen rather than a 404.
-  get "customers/:id/edit", to: redirect("/app/customers/%{id}/edit"), as: :edit_customer
+  get "customers/:id/edit", to: spa_screen.call("/app/customers/%{id}/edit"), as: :edit_customer
 
   # The SPA owns the project list and the form (phase B3). The detail page
   # stays here: it renders the offers and invoices panels, which belong to B6
   # and B7 — porting it now would mean building those twice. The names are
   # kept, since the main navigation links `projects_path` and the detail links
   # `edit_project_path`.
-  get "projects", to: redirect("/app/projects"), as: :projects
-  get "projects/new", to: redirect("/app/projects/new"), as: :new_project
-  get "projects/:id/edit", to: redirect("/app/projects/%{id}/edit"), as: :edit_project
+  get "projects", to: spa_screen.call("/app/projects"), as: :projects
+  get "projects/new", to: spa_screen.call("/app/projects/new"), as: :new_project
+  get "projects/:id/edit", to: spa_screen.call("/app/projects/%{id}/edit"), as: :edit_project
 
   resources :projects, only: [:show] do
     # Untouched: these serve the legacy invoice screen, not the project

--- a/test/integration/spa_cutover_links_test.rb
+++ b/test/integration/spa_cutover_links_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The paths the SPA took over still answer, because bookmarks and the links
+# on the screens that have not moved yet point at them. What they carry
+# matters as much as where they lead: a filtered list, a project preselected
+# for a new invoice and the screen to return to after signing in all travel
+# in the query string, which `redirect("/app/…")` drops on the floor.
+class SpaCutoverLinksTest < ActionDispatch::IntegrationTest
+  let(:id) { "aaaaaaaa-0000-4000-8000-000000000001" }
+
+  it "keeps a list's filters" do
+    get "/projects?state=archived"
+    assert_redirected_to "/app/projects?state=archived"
+
+    get "/invoices?year=2026&state=paid"
+    assert_redirected_to "/app/invoices?year=2026&state=paid"
+
+    get "/offers?year=2026"
+    assert_redirected_to "/app/offers?year=2026"
+  end
+
+  # `projects/show` links a new invoice for the project it is showing, and
+  # the form reads the project out of the query.
+  it "keeps the project a new invoice is for" do
+    get "/invoices/new?project_id=#{id}"
+    assert_redirected_to "/app/invoices/new?project_id=#{id}"
+
+    get "/offers/new?project_id=#{id}"
+    assert_redirected_to "/app/offers/new?project_id=#{id}"
+  end
+
+  it "keeps the screen to come back to after signing in" do
+    get "/signin?return=%2Fsettings"
+    assert_redirected_to "/app/login?return=%2Fsettings"
+  end
+
+  it "carries a record's id into its own screen" do
+    get "/invoices/#{id}"
+    assert_redirected_to "/app/invoices/#{id}"
+
+    get "/invoices/#{id}/edit"
+    assert_redirected_to "/app/invoices/#{id}/edit"
+
+    get "/offers/#{id}"
+    assert_redirected_to "/app/offers/#{id}"
+
+    get "/offers/#{id}/edit"
+    assert_redirected_to "/app/offers/#{id}/edit"
+
+    get "/customers/#{id}/edit"
+    assert_redirected_to "/app/customers/#{id}/edit"
+
+    get "/projects/#{id}/edit"
+    assert_redirected_to "/app/projects/#{id}/edit"
+  end
+
+  it "leads to the screen itself where there is nothing to carry" do
+    get "/projects/new"
+    assert_redirected_to "/app/projects/new"
+
+    get "/timesheet"
+    assert_redirected_to "/app/timesheet"
+  end
+end


### PR DESCRIPTION
Aufgefallen an einem Inline-Kommentar von Greptile in #1005: `redirect("/app/…")` wirft alles hinter dem Fragezeichen weg. Die Hälfte der bereits umgestellten Pfade war so geschrieben, die andere Hälfte mit einem Block, der den Query-String erhält — was beim Übergang überlebte, hing also davon ab, auf welcher Zeile man landete.

Gemessen an der laufenden App (Integrationstest, vorher):

```
/projects?state=archived  ->  /app/projects
/customers/abc/edit?x=1   ->  /app/customers/abc/edit
/users/password/new?x=1   ->  /app/password/new?x=1     ← der Block-Weg, korrekt
```

Was das konkret kostet:

- **`/projects?state=archived`** kommt ungefiltert an. Ein Lesezeichen auf die archivierten Projekte zeigt die aktiven.
- **`/invoices/new?project_id=…`** verliert das Projekt. Genau so bietet die (noch server-gerenderte) Projektseite „Neue Rechnung" an: `new_invoice_path(project_id: project)`. Das Formular liest das Projekt aus der Query — es kam nie an.
- **`/signin?return=%2Fsettings`** verliert den Screen, zu dem man nach dem Anmelden zurück wollte.

Alle Pfade laufen jetzt über `spa_screen`, das schon für die Devise-Links existierte und den Query-String erhält. Es kann jetzt zusätzlich `%{id}` interpolieren, damit auch die Datensatz-Pfade denselben Weg nehmen können — vier handgeschriebene Lambdas, die dasselbe taten, fallen dabei weg.

Ein Test läuft jede einzelne Route ab: Listenfilter, das vorausgewählte Projekt, der Rückkehr-Screen nach dem Login, die Datensatz-Pfade mit ihrer id, und die beiden ohne etwas zu tragen.

358 Ruby-Tests in `test/controllers` und `test/integration` grün.

🤖