### PR TITLE
feat(api): report what the project screen reads

### DIFF
--- a/app/api_components/v1/schemas/project.rb
+++ b/app/api_components/v1/schemas/project.rb
@@ -29,6 +29,10 @@ module V1
           # client does not have to re-implement the arithmetic.
           timerValues: {type: :string},
           budgetPercent: {type: [:string, :null]},
+          # The rest of what the detail screen prints above the chart.
+          timerValuesBillable: {type: :string},
+          timerValuesUninvoiced: {type: :string},
+          invoiceValues: {type: :string},
           tasks: {type: :array, items: V1::Schemas::ProjectTask},
           createdAt: {type: :string, format: "date-time"},
           updatedAt: {type: :string, format: "date-time"},

--- a/app/api_components/v1/schemas/project_chart.rb
+++ b/app/api_components/v1/schemas/project_chart.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    # What a project's budget chart is drawn from: the billable work booked
+    # against it, added up week by week, against the budget it has.
+    class ProjectChart
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          labels: {type: :array, items: {type: :string}, description: "The Monday of each week."},
+          datasets: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                name: {type: [:string, :null]},
+                color: {type: [:string, :null]},
+                data: {type: :array, items: {type: [:number, :string]}},
+                zone: {
+                  type: [:integer, :null],
+                  description: "Index up to which the series is drawn solid; past it are the weeks that have not happened yet."
+                }
+              },
+              additionalProperties: false,
+              required: %w[name color data zone]
+            }
+          },
+          # Decimals cross the wire as strings.
+          budget: {type: [:string, :null], description: "Drawn as the line the work is measured against."},
+          ticks: {
+            type: :array,
+            items: {type: :integer},
+            description: "The weeks a month begins in, which is where the axis is labelled."
+          }
+        },
+        additionalProperties: false,
+        required: %w[labels datasets ticks]
+      })
+    end
+  end
+end

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -160,7 +160,8 @@ module Api
       end
 
       private def filter_params
-        params.permit(:state, :year, :quarter, :month, :paid_in_year, :paid_in_quarter, :paid_in_month)
+        params.permit(:state, :year, :quarter, :month, :paid_in_year, :paid_in_quarter, :paid_in_month,
+          :project_id)
       end
 
       private def invoice_params

--- a/app/controllers/api/v1/offers_controller.rb
+++ b/app/controllers/api/v1/offers_controller.rb
@@ -123,7 +123,7 @@ module Api
       end
 
       private def filter_params
-        params.permit(:state, :year)
+        params.permit(:state, :year, :project_id)
       end
 
       private def offer_params

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -34,6 +34,16 @@ module Api
         authorize! :read, @project
       end
 
+      # The budget chart, which is its own request rather than part of the
+      # project: the form reads the project too, and would be paying for a
+      # chart it never draws.
+      def chart
+        @project = current_account.projects.find(params[:id])
+        authorize! :read, @project
+
+        @chart = ::Charts::ProjectBudgetService.new(@project, @project.timers.billable).data
+      end
+
       def create
         @project = current_account.projects.new(project_params)
         authorize! :create, @project

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -104,6 +104,7 @@ class Invoice < ApplicationRecord
         filter_params.fetch(:paid_in_month, nil),
         filter_params.fetch(:paid_in_year, Time.current.year)
       )
+      .filter_project(filter_params.fetch(:project_id, nil))
   end
 
   def self.filter_year(year)
@@ -131,6 +132,13 @@ class Invoice < ApplicationRecord
       start_date: Date.new(year.to_i, month.to_i, 1),
       end_date: Date.new(year.to_i, month.to_i, -1)
     )
+  end
+
+  # The project screen lists what belongs to the project it is showing.
+  def self.filter_project(project_id)
+    return all if project_id.blank?
+
+    where(project_id: project_id)
   end
 
   def self.filter_state(state)

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -57,6 +57,14 @@ class Offer < ApplicationRecord
   def self.filter_result(filter_params)
     filter_year(filter_params.fetch(:year, nil))
       .filter_state(filter_params.fetch(:state, nil))
+      .filter_project(filter_params.fetch(:project_id, nil))
+  end
+
+  # The project screen lists what belongs to the project it is showing.
+  def self.filter_project(project_id)
+    return all if project_id.blank?
+
+    where(project_id: project_id)
   end
 
   def self.filter_year(year)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -51,8 +51,11 @@ class Project < ApplicationRecord
     "#{customer.name} - #{name}"
   end
 
+  # Seeded with a decimal: these cross the wire as strings, and a project
+  # with nothing booked against it would otherwise answer a bare float where
+  # every other answer is a string.
   def timer_values
-    values = 0.0
+    values = 0.to_d
     timers.each do |timer|
       values += timer.value.to_d if timer.value.present?
     end
@@ -60,7 +63,7 @@ class Project < ApplicationRecord
   end
 
   def timer_values_billable
-    values = 0.0
+    values = 0.to_d
     timers.billable.each do |timer|
       values += timer.value.to_d if timer.value.present?
     end
@@ -68,7 +71,7 @@ class Project < ApplicationRecord
   end
 
   def timer_values_invoiced
-    values = 0.0
+    values = 0.to_d
     timers.each do |timer|
       values += timer.value.to_d if timer.value.present? && timer.position_id.present?
     end
@@ -76,7 +79,7 @@ class Project < ApplicationRecord
   end
 
   def timer_values_uninvoiced
-    values = 0.0
+    values = 0.to_d
     timers.billable.each do |timer|
       values += timer.value.to_d if timer.value.present? && timer.position_id.blank?
     end
@@ -84,7 +87,7 @@ class Project < ApplicationRecord
   end
 
   def invoice_values
-    values = 0.0
+    values = 0.to_d
     invoices.each do |invoice|
       values += invoice.value.to_d
     end

--- a/app/views/api/v1/projects/_show.json.jbuilder
+++ b/app/views/api/v1/projects/_show.json.jbuilder
@@ -15,6 +15,12 @@ json.invoice_addition project.invoice_addition
 json.start_date project.start_date
 json.end_date project.end_date
 json.timer_values project.timer_values
+# What the four numbers above the chart are: the hours booked, the billable
+# part of them, the part not on an invoice yet, and what the invoices for
+# this project add up to.
+json.timer_values_billable project.timer_values_billable
+json.timer_values_uninvoiced project.timer_values_uninvoiced
+json.invoice_values project.invoice_values
 # Dividing by a budget of zero is what the ERB guarded against before it drew
 # the bar, so the client gets nothing to draw rather than an infinity.
 json.budget_percent((project.budget_hours.to_d.zero? && project.budget.to_d.zero?) ? nil : project.budget_percent)

--- a/app/views/api/v1/projects/chart.json.jbuilder
+++ b/app/views/api/v1/projects/chart.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.labels @chart[:labels]
+json.datasets @chart[:datasets] do |dataset|
+  json.name dataset[:name]
+  json.color dataset[:color]
+  json.data dataset[:data]
+  json.zone dataset[:zone]
+end
+json.budget @chart[:budget]
+json.ticks @chart[:ticks]

--- a/config/routes/api_v1_routes.rb
+++ b/config/routes/api_v1_routes.rb
@@ -42,6 +42,7 @@ v1_api_routes = lambda do
 
   resources :projects, only: %i[index show create update destroy] do
     member do
+      get :chart
       put :archive
       put :unarchive
     end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -1049,6 +1049,14 @@ paths:
         required: false
         schema:
           type: integer
+      - name: project_id
+        in: query
+        required: false
+        description: Only what belongs to this project, which is what its own screen
+          lists.
+        schema:
+          type: string
+          format: uuid
       - name: sort
         in: query
         required: false
@@ -1683,6 +1691,14 @@ paths:
         required: false
         schema:
           type: integer
+      - name: project_id
+        in: query
+        required: false
+        description: Only what belongs to this project, which is what its own screen
+          lists.
+        schema:
+          type: string
+          format: uuid
       - name: sort
         in: query
         required: false
@@ -2216,6 +2232,40 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/projects/{id}/chart":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    get:
+      summary: What a project's budget chart is drawn from
+      tags:
+      - Projects
+      operationId: projectChart
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ProjectChart"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/projects/{id}/unarchive":
     parameters:
     - name: id
@@ -4553,6 +4603,12 @@ components:
           type:
           - string
           - 'null'
+        timerValuesBillable:
+          type: string
+        timerValuesUninvoiced:
+          type: string
+        invoiceValues:
+          type: string
         tasks:
           type: array
           items:
@@ -4583,6 +4639,61 @@ components:
       - createdAt
       - updatedAt
       title: Project
+    ProjectChart:
+      type: object
+      properties:
+        labels:
+          type: array
+          items:
+            type: string
+          description: The Monday of each week.
+        datasets:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type:
+                - string
+                - 'null'
+              color:
+                type:
+                - string
+                - 'null'
+              data:
+                type: array
+                items:
+                  type:
+                  - number
+                  - string
+              zone:
+                type:
+                - integer
+                - 'null'
+                description: Index up to which the series is drawn solid; past it
+                  are the weeks that have not happened yet.
+            additionalProperties: false
+            required:
+            - name
+            - color
+            - data
+            - zone
+        budget:
+          type:
+          - string
+          - 'null'
+          description: Drawn as the line the work is measured against.
+        ticks:
+          type: array
+          items:
+            type: integer
+          description: The weeks a month begins in, which is where the axis is labelled.
+      additionalProperties: false
+      required:
+      - labels
+      - datasets
+      - ticks
+      title: ProjectChart
     ProjectInput:
       type: object
       properties:

--- a/test/integration/api/v1/invoices_test.rb
+++ b/test/integration/api/v1/invoices_test.rb
@@ -25,6 +25,9 @@ module Api
           parameter name: "paid_in_year", in: :query, required: false, schema: {type: :integer}
           parameter name: "paid_in_quarter", in: :query, required: false, schema: {type: :integer}
           parameter name: "paid_in_month", in: :query, required: false, schema: {type: :integer}
+          parameter name: "project_id", in: :query, required: false,
+            description: "Only what belongs to this project, which is what its own screen lists.",
+            schema: {type: :string, format: :uuid}
           parameter name: "sort", in: :query, required: false,
             description: "Column to order by. Anything else falls back to the newest first.",
             schema: {type: :string, enum: %w[ref date value state customer]}
@@ -154,6 +157,22 @@ module Api
         it "filters by state" do
           assert_api_response :get, 200, params: {state: "paid"} do
             refute_includes parsed_body.map { |item| item["id"] }, invoice.id
+          end
+        end
+
+        # The project screen lists what belongs to the project it shows.
+        it "lists only what belongs to a project when asked" do
+          other = projects(:outpost6)
+          mine = data.account.invoices.create!(
+            customer: customers(:starfleet), project: other, date: Date.new(2026, 5, 1),
+            ref: data.account.invoices.maximum(:ref).to_i + 1
+          )
+
+          assert_api_response :get, 200, params: {project_id: other.id} do
+            ids = parsed_body.map { |item| item["id"] }
+
+            assert_includes ids, mine.id
+            assert_equal [other.id], parsed_body.map { |item| item["projectId"] }.uniq
           end
         end
 

--- a/test/integration/api/v1/offers_test.rb
+++ b/test/integration/api/v1/offers_test.rb
@@ -20,6 +20,9 @@ module Api
           parameter name: "state", in: :query, required: false,
             schema: {type: :string, enum: %w[created bided accepted declined canceled]}
           parameter name: "year", in: :query, required: false, schema: {type: :integer}
+          parameter name: "project_id", in: :query, required: false,
+            description: "Only what belongs to this project, which is what its own screen lists.",
+            schema: {type: :string, format: :uuid}
           parameter name: "sort", in: :query, required: false,
             description: "Column to order by. Anything else falls back to the newest first.",
             schema: {type: :string, enum: %w[ref date value state customer]}
@@ -79,6 +82,20 @@ module Api
 
       describe "signed in" do
         before { sign_in data }
+
+        # The project screen lists what belongs to the project it shows.
+        it "lists only what belongs to a project when asked" do
+          other = projects(:outpost6)
+          mine = account.offers.create!(
+            customer: customers(:starfleet), project: other, date: Date.new(2026, 5, 1),
+            ref: account.offers.maximum(:ref).to_i + 1
+          )
+
+          assert_api_response :get, 200, params: {project_id: other.id} do
+            assert_includes parsed_body.map { |item| item["id"] }, mine.id
+            assert_equal [other.id], parsed_body.map { |item| item["projectId"] }.uniq
+          end
+        end
 
         it "lists the account's offers with their positions" do
           assert_api_response :get, 200 do

--- a/test/integration/api/v1/project_chart_test.rb
+++ b/test/integration/api/v1/project_chart_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+module Api
+  module V1
+    # Its own class because the DSL matches on verb and path params, which
+    # cannot tell `GET /projects/{id}` and `GET /projects/{id}/chart` apart.
+    class ProjectChartTest < ActionDispatch::IntegrationTest
+      include OpenapiRuby::Adapters::Minitest::DSL
+
+      openapi_schema :"v1/schema"
+
+      api_path "/projects/{id}/chart" do
+        parameter name: "id", in: :path, required: true, schema: {type: :string, format: :uuid}
+
+        get("What a project's budget chart is drawn from") do
+          operationId "projectChart"
+          tags "Projects"
+          produces "application/json"
+
+          response(200, "successful") do
+            schema ::V1::Schemas::ProjectChart
+          end
+
+          response(404, "not found") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(401, "unauthorized") do
+            schema ::V1::Schemas::StandardError
+          end
+        end
+      end
+
+      let(:data) { users :data }
+      let(:account) { accounts :enterprise }
+      let(:project) { projects :narendra3 }
+
+      it "is unauthorized when signed out" do
+        assert_api_response :get, 401, path_params: {id: project.id}
+      end
+
+      describe "signed in" do
+        before { sign_in data }
+
+        # A week per label, from the project's start to its end, and the
+        # months are where the axis is labelled.
+        it "reports a week per label and the months among them" do
+          project.update!(start_date: 8.weeks.ago, end_date: 1.week.from_now, budget: 10_000, rate: 100)
+
+          assert_api_response :get, 200, path_params: {id: project.id} do
+            assert_operator parsed_body["labels"].size, :>=, 8
+            assert_kind_of Array, parsed_body["ticks"]
+            assert_equal 10_000.0, parsed_body["budget"].to_f
+          end
+        end
+
+        # The line the work is measured against, and the work itself as a
+        # running total of what has been booked and is billable.
+        # `outpost6` rather than the project the timer fixtures hang off, so
+        # the sum is only what this test booked.
+        it "adds the billable work up week by week" do
+          quiet = projects(:outpost6)
+          quiet.update!(start_date: 3.weeks.ago, end_date: 1.week.from_now, budget: 10_000, rate: 100)
+          task = quiet.tasks.create!(name: "Away mission", billable: true)
+          # A timer belongs to a task, which is what ties it to the project.
+          task.timers.create!(user: data, date: 2.weeks.ago.to_date, value: 5)
+
+          assert_api_response :get, 200, path_params: {id: quiet.id} do
+            series = parsed_body["datasets"].first
+
+            assert series, "expected a series for a project with a budget"
+            # 5 hours at 100 an hour, carried forward from the week it was
+            # booked in.
+            assert_equal 500.0, series["data"].last.to_f
+            assert_kind_of Integer, series["zone"]
+          end
+        end
+
+        # Without a budget there is nothing to measure against, so the chart
+        # has labels and no series rather than a line at zero.
+        it "draws no series for a project without a budget" do
+          project.update!(budget: 0)
+
+          assert_api_response :get, 200, path_params: {id: project.id} do
+            assert_empty parsed_body["datasets"]
+          end
+        end
+
+        it "is not found for another account's project" do
+          other = accounts(:defiant).customers.create!(name: "Tal Shiar")
+            .projects.create!(name: "Cloaking device")
+
+          assert_api_response :get, 404, path_params: {id: other.id}
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Vorbereitung für das Projekt-Detail, die letzte Detailseite in ERB. Drei Dinge, die der Screen liest und die API nicht hatte.

### Die Zahlen über dem Chart

Der Screen zeigt vier: erfasste Stunden, verbleibende Stunden, verbleibendes Budget, offener Betrag. Die Stunden waren da; `timerValuesBillable`, `timerValuesUninvoiced` und `invoiceValues` nicht — und genau aus denen rechnen sich die anderen drei.

### `GET /projects/:id/chart`

Die abrechenbare Arbeit, Woche für Woche aufaddiert, gegen das Budget als Linie — dazu die Wochen, in denen ein Monat beginnt, damit die Achse dort beschriftet wird, wo die alte es tat. `Charts::ProjectBudgetService` unverändert, nur als JSON.

Eigener Request statt Teil des Projekts: das Formular liest das Projekt auch und würde sonst einen Chart mitbezahlen, den es nie zeichnet.

### `project_id` als Filter

Die Rechnungs- und Angebotslisten konnten nicht nach Projekt filtern — so füllt der Screen aber seine zwei Tabs. Steht jetzt in beiden `filter_result`, ist in beiden Verträgen dokumentiert und in beiden getestet.

### Und ein Fehler dabei

Die fünf Summen an `Project` (`timer_values`, `_billable`, `_invoiced`, `_uninvoiced`, `invoice_values`) starten bei `0.0` und werden erst durch Addition zu Decimals. Ein Projekt ohne gebuchte Zeit antwortet damit `0.0` als **Zahl**, wo jede andere Antwort ein String ist — und `timerValues` ist im Vertrag als `string` deklariert, ein leeres Projekt bricht ihn also. Eigener Commit; dieselbe Familie wie der Fehler in #1004.

Fünf Integrationstests für den Chart, je einer für die zwei Filter. 445 Ruby-Tests grün, typecheck grün.

Als Nächstes der Screen selbst — inklusive der vier Tabs, wobei der Zeiten-Tab die Vue-Insel `timers-calendar` ist, die dort schon läuft.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a project budget chart API with weekly labels, budget details, tick markers, and billable time datasets.
  - Project responses now include billable, uninvoiced, and invoice value metrics.
  - Added optional project filtering for invoice and offer list endpoints.
  - Expanded API documentation for the new chart endpoint, metrics, and filtering options.

- **Bug Fixes**
  - Project financial values now retain consistent decimal formatting, including when no time or invoices are recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->