### PR TITLE
fix(spa): dress the timers calendar for the SPA

### DIFF
--- a/app/frontend/components/ui/UiProgress.vue
+++ b/app/frontend/components/ui/UiProgress.vue
@@ -20,6 +20,6 @@ const fill = computed(() => {
 
 <template>
   <div class="bs-progress">
-    <div class="h-full" :class="fill" :style="{ width: `${width}%` }"></div>
+    <div class="bs-progress-bar" :class="fill" :style="{ width: `${width}%` }"></div>
   </div>
 </template>

--- a/app/frontend/entrypoints/application.ts
+++ b/app/frontend/entrypoints/application.ts
@@ -20,7 +20,6 @@ import { configureAccounting, installAccountingGlobal } from "../lib/accounting"
 import { configureMomentLocale } from "../lib/moment-locale"
 import { mountIslands } from "../lib/mount-islands"
 import Hello from "../islands/hello/Hello.vue"
-import TimersCalendar from "../islands/timers-calendar/TimersCalendar.vue"
 
 // PDF.js v4+ ships ESM-only. Lazy-loaded so the 1.5 MB pdfjs core +
 // worker don't ship on pages that never render a PDF (most of them).
@@ -140,13 +139,12 @@ if (i18nGlobal) {
 // + ISO week here, replacing what `App.Moment.init` used to do.
 configureMomentLocale()
 
-// Vue islands on the server-rendered pages. The timesheet left in phase B3+
-// — it is an SPA page now — so what is left here is the timers calendar,
-// which goes the same way in B5, and the `hello` smoke test that retires with
-// the mounter itself in phase C.
+// Vue islands on the server-rendered pages. Both the timesheet and the
+// project screen the timers calendar was mounted on are SPA pages now, so
+// what is left is the `hello` smoke test that retires with the mounter itself
+// in phase C.
 const islandRegistry = {
   hello: Hello,
-  "timers-calendar": TimersCalendar,
 }
 mountIslands(islandRegistry)
 document.addEventListener("turbo:load", () => mountIslands(islandRegistry))

--- a/app/frontend/entrypoints/spa.css
+++ b/app/frontend/entrypoints/spa.css
@@ -653,6 +653,7 @@
     line-height: 1;
     color: #ffffff;
     white-space: nowrap;
+    text-align: left;
     text-overflow: ellipsis;
     overflow: hidden;
     vertical-align: baseline;

--- a/app/frontend/entrypoints/spa.css
+++ b/app/frontend/entrypoints/spa.css
@@ -41,7 +41,10 @@
   --color-rule-strong: #dddddd;
 
   --color-muted: #777777;
+  --color-muted-hover: #5e5e5e;
   --color-muted-strong: #666666;
+  /* `lighten($brand-primary, 30%)`, which marks today in the calendar. */
+  --color-brand-faint: #b9d4ec;
   --color-surface: #ffffff;
   --color-surface-muted: #f5f5f5;
   --color-surface-stripe: #f9f9f9;
@@ -58,6 +61,7 @@
   --color-success-hover-border: #398439;
   --color-info: #5bc0de;
   --color-info-border: #46b8da;
+  --color-info-hover: #31b0d5;
   --color-warning: #f0ad4e;
   --color-warning-border: #eea236;
   /* `button-variant` darkens the fill by 10% on hover and the border by 12%,
@@ -340,6 +344,12 @@
     box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
   }
 
+  .bs-progress-bar {
+    height: 100%;
+    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+    transition: width 0.6s ease;
+  }
+
   /* `.modal-content` and `.modal-dialog`. */
   .bs-modal {
     background-color: var(--color-surface);
@@ -541,6 +551,143 @@
     background-color: var(--color-surface-muted);
     padding: 15px;
     margin-top: 15px;
+  }
+
+  /* `partials/_calendar.scss`: a month as seven inline-block columns per
+     week, each cell a hundred pixels tall with the timers booked on that day
+     stacked inside it. */
+  .bs-calendar {
+    border: 1px solid var(--color-rule-strong);
+    border-radius: var(--radius-bs-sm);
+    overflow-x: auto;
+  }
+
+  .bs-calendar-header,
+  .bs-calendar-week {
+    white-space: nowrap;
+  }
+
+  .bs-calendar-day {
+    display: inline-block;
+    width: calc(100% / 7);
+    min-width: 100px;
+    padding: 5px;
+    vertical-align: top;
+  }
+
+  .bs-calendar-header .bs-calendar-day {
+    font-weight: bold;
+    border-right: 1px solid var(--color-rule-strong);
+  }
+
+  .bs-calendar-header .bs-calendar-day:last-child {
+    border-right: none;
+  }
+
+  .bs-calendar-week .bs-calendar-day {
+    position: relative;
+    height: 100px;
+    border: 1px solid var(--color-rule-strong);
+    border-width: 1px 1px 0 0;
+    background-color: #e8e8e8;
+  }
+
+  .bs-calendar-week .bs-calendar-day:last-child {
+    border-width: 1px 0 0 0;
+  }
+
+  /* A day of the month being shown, rather than one of the days either side
+     of it the grid fills its first and last week with. */
+  .bs-calendar-week .bs-calendar-day.is-current-month {
+    background-color: var(--color-surface-muted);
+  }
+
+  .bs-calendar-week .bs-calendar-day.is-current-day {
+    background-color: var(--color-brand-faint);
+  }
+
+  .bs-calendar-week:first-child .bs-calendar-day:first-child {
+    border-radius: var(--radius-bs-sm) 0 0 0;
+  }
+
+  .bs-calendar-week:first-child .bs-calendar-day:last-child {
+    border-radius: 0 var(--radius-bs-sm) 0 0;
+  }
+
+  .bs-calendar-week:last-child .bs-calendar-day:first-child {
+    border-radius: 0 0 0 var(--radius-bs-sm);
+  }
+
+  .bs-calendar-week:last-child .bs-calendar-day:last-child {
+    border-radius: 0 0 var(--radius-bs-sm) 0;
+  }
+
+  .bs-calendar-day-number {
+    float: left;
+    margin-top: -2px;
+    margin-right: 5px;
+    color: var(--color-muted-strong);
+    text-decoration: none;
+  }
+
+  .bs-calendar-day-number:hover {
+    color: #1a1a1a;
+  }
+
+  .bs-calendar-add {
+    position: absolute;
+    right: 5px;
+    bottom: 5px;
+    cursor: pointer;
+  }
+
+  /* A booked timer, which is a label in everything but its width. */
+  .bs-calendar-timer {
+    display: block;
+    float: left;
+    max-width: 100%;
+    margin-bottom: 2px;
+    padding: 0.2em 0.6em 0.3em;
+    font-size: 80%;
+    font-weight: bold;
+    line-height: 1;
+    color: #ffffff;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    vertical-align: baseline;
+    border-radius: 0.25em;
+    background-color: var(--color-muted);
+    cursor: pointer;
+  }
+
+  .bs-calendar-timer:hover {
+    background-color: var(--color-muted-hover);
+    text-decoration: none;
+  }
+
+  .bs-calendar-timer.is-billable {
+    background-color: var(--color-info);
+  }
+
+  .bs-calendar-timer.is-billable:hover {
+    background-color: var(--color-info-hover);
+  }
+
+  .bs-calendar-timer.is-running {
+    background-color: var(--color-warning);
+  }
+
+  .bs-calendar-timer.is-running:hover {
+    background-color: var(--color-warning-hover);
+  }
+
+  .bs-calendar-timer.is-invoiced {
+    background-color: var(--color-success);
+  }
+
+  .bs-calendar-timer.is-invoiced:hover {
+    background-color: var(--color-success-hover);
   }
 
   .bs-caret {

--- a/app/frontend/islands/timers-calendar/TimersCalendar.vue
+++ b/app/frontend/islands/timers-calendar/TimersCalendar.vue
@@ -10,6 +10,7 @@ import {listProjects} from "../../lib/timers/api"
 import {businessDaysInMonth} from "../../lib/timers/format"
 import type {Task, Timer} from "../../lib/timers/types"
 import UiAlert from "../../components/ui/UiAlert.vue"
+import UiButton from "../../components/ui/UiButton.vue"
 
 interface Labels {
   weekDays: string
@@ -120,7 +121,7 @@ const businessDays = computed(() => businessDaysInMonth(month.value))
 
     <UiAlert v-if="error" variant="danger">
       {{ t("timesheet.timersFailed") }}
-      <a role="button" @click.prevent="refresh">{{ t("timesheet.retry") }}</a>
+      <UiButton variant="link" class="px-0" @click="refresh">{{ t("timesheet.retry") }}</UiButton>
     </UiAlert>
 
     <MonthGrid

--- a/app/frontend/islands/timers-calendar/TimersCalendar.vue
+++ b/app/frontend/islands/timers-calendar/TimersCalendar.vue
@@ -12,48 +12,32 @@ import type {Task, Timer} from "../../lib/timers/types"
 import UiAlert from "../../components/ui/UiAlert.vue"
 import UiButton from "../../components/ui/UiButton.vue"
 
-interface Labels {
-  weekDays: string
-  today: string
-  addTimer: string
-  dayShort: string[]
-}
-
-const props = defineProps<{
-  projectId: string
-  labels?: Labels
-  monthLabels?: string[]
-}>()
+const props = defineProps<{projectId: string}>()
 
 const emit = defineEmits<{changed: []}>()
 
-const {t} = useI18n()
+const {t, locale} = useI18n()
 
-const labels = computed<Labels>(() => ({
-  weekDays: "weekdays",
-  today: "Today",
-  addTimer: "Add timer",
-  dayShort: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
-  ...(props.labels ?? {}),
+// The names of the days and the months come from the locale rather than from
+// the catalogues, and the calendar reads them itself — the screen used to
+// hand them in, from the days when a server-rendered page mounted this.
+const labels = computed(() => ({
+  weekDays: t("timersCalendar.weekDays"),
+  today: t("timersCalendar.today"),
+  addTimer: t("timersCalendar.addTimer"),
+  dayShort: Array.from({length: 7}, (_, index) =>
+    new Intl.DateTimeFormat(locale.value, {weekday: "short", timeZone: "UTC"}).format(
+      new Date(Date.UTC(2024, 0, 1 + index)),
+    ),
+  ),
 }))
 
-const monthLabels = computed<string[]>(() =>
-  props.monthLabels && props.monthLabels.length === 12
-    ? props.monthLabels
-    : [
-        "January",
-        "February",
-        "March",
-        "April",
-        "May",
-        "June",
-        "July",
-        "August",
-        "September",
-        "October",
-        "November",
-        "December",
-      ],
+const monthLabels = computed(() =>
+  Array.from({length: 12}, (_, index) =>
+    new Intl.DateTimeFormat(locale.value, {month: "long", timeZone: "UTC"}).format(
+      new Date(Date.UTC(2024, index, 1)),
+    ),
+  ),
 )
 
 const {month, prev, next, today, set: setMonth} = useMonth()

--- a/app/frontend/islands/timers-calendar/TimersCalendar.vue
+++ b/app/frontend/islands/timers-calendar/TimersCalendar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {computed, onMounted, ref, shallowRef} from "vue"
-import {visit} from "@hotwired/turbo"
+import {useI18n} from "vue-i18n"
 import MonthGrid from "./components/MonthGrid.vue"
 import MonthNav from "./components/MonthNav.vue"
 import TimerModal from "./components/TimerModal.vue"
@@ -9,6 +9,7 @@ import {useTimers} from "./composables/useTimers"
 import {listProjects} from "../../lib/timers/api"
 import {businessDaysInMonth} from "../../lib/timers/format"
 import type {Task, Timer} from "../../lib/timers/types"
+import UiAlert from "../../components/ui/UiAlert.vue"
 
 interface Labels {
   weekDays: string
@@ -17,22 +18,15 @@ interface Labels {
   dayShort: string[]
 }
 
-const props = withDefaults(
-  defineProps<{
-    projectId: string
-    labels?: Labels
-    monthLabels?: string[]
-    /**
-     * An island on a server-rendered screen reloads it after a change, since
-     * the numbers around it are rendered there. Inside the SPA the screen
-     * refreshes itself, so it asks for the event instead.
-     */
-    standalone?: boolean
-  }>(),
-  {labels: undefined, monthLabels: undefined, standalone: true},
-)
+const props = defineProps<{
+  projectId: string
+  labels?: Labels
+  monthLabels?: string[]
+}>()
 
 const emit = defineEmits<{changed: []}>()
+
+const {t} = useI18n()
 
 const labels = computed<Labels>(() => ({
   weekDays: "weekdays",
@@ -104,20 +98,14 @@ function closeModal() {
 // shouldn't trigger a page refresh.
 function onModalChanged() {
   refresh()
-
-  if (!props.standalone) {
-    emit("changed")
-    return
-  }
-
-  visit(window.location.href, {action: "replace"})
+  emit("changed")
 }
 
 const businessDays = computed(() => businessDaysInMonth(month.value))
 </script>
 
 <template>
-  <div class="col-xs-12" data-test="timers-calendar">
+  <div data-test="timers-calendar">
     <MonthNav
       :month="month"
       :business-days="businessDays"
@@ -130,24 +118,20 @@ const businessDays = computed(() => businessDaysInMonth(month.value))
       @jump="setMonth"
     />
 
-    <div v-if="error" class="alert alert-danger">
-      Failed to load timers.
-      <a role="button" @click.prevent="refresh">Retry</a>
-    </div>
+    <UiAlert v-if="error" variant="danger">
+      {{ t("timesheet.timersFailed") }}
+      <a role="button" @click.prevent="refresh">{{ t("timesheet.retry") }}</a>
+    </UiAlert>
 
-    <div class="row">
-      <div class="col-xs-12">
-        <MonthGrid
-          :month="month"
-          :timers="timers"
-          :day-short-labels="labels.dayShort"
-          :add-timer-title="labels.addTimer"
-          @add="openAdd"
-          @edit="openEdit"
-        />
-        <p v-if="loading" class="text-muted text-right" style="margin-top: 4px">Loading…</p>
-      </div>
-    </div>
+    <MonthGrid
+      :month="month"
+      :timers="timers"
+      :day-short-labels="labels.dayShort"
+      :add-timer-title="labels.addTimer"
+      @add="openAdd"
+      @edit="openEdit"
+    />
+    <p v-if="loading" class="mt-1 text-right text-muted">{{ t("timesheet.loading") }}</p>
 
     <TimerModal
       v-if="modalDraft && tasksLoaded"

--- a/app/frontend/islands/timers-calendar/components/MonthGrid.vue
+++ b/app/frontend/islands/timers-calendar/components/MonthGrid.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-// Markup mirrors `app/views/templates/timers/month.html.erb` so the
-// `_calendar.scss` partial applies. Classes used:
-//   .calendar > .header > .day  (header row)
-//   .calendar > .week  > .day { .current-month | .current-day }
-//   .day > .day-number, .day > .timers > .timer / .add-timer
+// A month as seven columns per week, styled by the `.bs-calendar` classes
+// `spa.css` measured out of `partials/_calendar.scss`.
 
 import {computed} from "vue"
+import {RouterLink} from "vue-router"
 import {buildWeeks} from "../calendar"
 import type {Timer} from "../../../lib/timers/types"
 import TimerBadge from "./TimerBadge.vue"
@@ -36,23 +34,26 @@ const byDate = computed(() => {
 </script>
 
 <template>
-  <div class="calendar">
-    <div class="header">
-      <div v-for="(day, i) in dayShortLabels" :key="i" class="day">
+  <div class="bs-calendar">
+    <div class="bs-calendar-header">
+      <div v-for="(day, i) in dayShortLabels" :key="i" class="bs-calendar-day">
         <span>{{ day }}</span>
       </div>
     </div>
-    <div v-for="(week, wi) in weeks" :key="wi" class="week">
+    <div v-for="(week, wi) in weeks" :key="wi" class="bs-calendar-week">
       <div
         v-for="cell in week.days"
         :key="cell.date"
-        class="day"
-        :class="{'current-month': cell.isCurrentMonth, 'current-day': cell.isCurrentDay}"
+        class="bs-calendar-day"
+        :class="{
+          'is-current-month': cell.isCurrentMonth,
+          'is-current-day': cell.isCurrentDay,
+        }"
       >
-        <a class="day-number" :href="`/timesheet?date=${cell.date}`" data-turbo="false">{{
-          cell.day
-        }}</a>
-        <div class="timers">
+        <RouterLink class="bs-calendar-day-number" :to="{name: 'timesheet', query: {date: cell.date}}">
+          {{ cell.day }}
+        </RouterLink>
+        <div>
           <TimerBadge
             v-for="timer in byDate.get(cell.date) ?? []"
             :key="timer.id"
@@ -60,7 +61,7 @@ const byDate = computed(() => {
             @click="emit('edit', timer)"
           />
           <a
-            class="add-timer"
+            class="bs-calendar-add"
             role="button"
             :title="addTimerTitle"
             @click.prevent="emit('add', cell.date)"

--- a/app/frontend/islands/timers-calendar/components/MonthGrid.vue
+++ b/app/frontend/islands/timers-calendar/components/MonthGrid.vue
@@ -60,14 +60,14 @@ const byDate = computed(() => {
             :timer="timer"
             @click="emit('edit', timer)"
           />
-          <a
-            class="bs-calendar-add"
-            role="button"
+          <button
+            type="button"
+            class="bs-calendar-add text-brand hover:text-brand-hover"
             :title="addTimerTitle"
-            @click.prevent="emit('add', cell.date)"
+            @click="emit('add', cell.date)"
           >
             <i class="fa fa-plus" aria-hidden="true"></i>
-          </a>
+          </button>
         </div>
       </div>
     </div>

--- a/app/frontend/islands/timers-calendar/components/MonthNav.vue
+++ b/app/frontend/islands/timers-calendar/components/MonthNav.vue
@@ -3,6 +3,7 @@
 // a native month picker behind a calendar icon, today, forward.
 
 import {computed, ref} from "vue"
+import {useI18n} from "vue-i18n"
 import UiButton from "../../../components/ui/UiButton.vue"
 
 const props = defineProps<{
@@ -12,6 +13,12 @@ const props = defineProps<{
   weekDaysLabel: string
   monthLabels: string[]
 }>()
+
+const {t} = useI18n()
+
+const previousLabel = computed(() => t("timesheet.previousDay"))
+const nextLabel = computed(() => t("timesheet.nextDay"))
+const pickMonthLabel = computed(() => t("timesheet.pickDate"))
 
 const emit = defineEmits<{
   prev: []
@@ -65,11 +72,17 @@ function onMonthInput(e: Event) {
     </h2>
 
     <div class="bs-btn-group">
-      <UiButton as="a" role="button" @click.prevent="emit('prev')">
+      <UiButton :title="previousLabel" @click="emit('prev')">
         <i class="fa fa-chevron-left" aria-hidden="true"></i>
       </UiButton>
-      <UiButton as="a" role="button" class="month-picker-trigger" @click.prevent="openPicker">
-        <i class="fa fa-calendar" aria-hidden="true"></i>
+
+      <!-- The input is a sibling rather than a child of the button: it is
+           what `showPicker()` opens, and a form control inside a button is a
+           second control inside the first. -->
+      <span class="relative inline-flex">
+        <UiButton class="rounded-none" :title="pickMonthLabel" @click="openPicker">
+          <i class="fa fa-calendar" aria-hidden="true"></i>
+        </UiButton>
         <input
           ref="hiddenInputRef"
           type="month"
@@ -79,16 +92,13 @@ function onMonthInput(e: Event) {
           aria-hidden="true"
           @change="onMonthInput"
         />
-      </UiButton>
-      <UiButton
-        as="a"
-        role="button"
-        :class="{'pointer-events-none opacity-65': isToday}"
-        @click.prevent="!isToday && emit('today')"
-      >
+      </span>
+
+      <UiButton :disabled="isToday" @click="emit('today')">
         {{ todayLabel }}
       </UiButton>
-      <UiButton as="a" role="button" @click.prevent="emit('next')">
+
+      <UiButton :title="nextLabel" @click="emit('next')">
         <i class="fa fa-chevron-right" aria-hidden="true"></i>
       </UiButton>
     </div>
@@ -96,9 +106,6 @@ function onMonthInput(e: Event) {
 </template>
 
 <style scoped>
-.month-picker-trigger {
-  position: relative;
-}
 /* Hide the native `<input type="month">` UI but keep it functional
  * — the visible calendar icon triggers showPicker() programmatically.
  * Negative z-index + opacity:0 + pointer-events:none keeps it from

--- a/app/frontend/islands/timers-calendar/components/MonthNav.vue
+++ b/app/frontend/islands/timers-calendar/components/MonthNav.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-// Markup mirrors the legacy `app/views/templates/timers/month.html.erb`
-// so the existing Bootstrap 3 `.btn`/`.resource-nav` styles and the
-// `_calendar.scss` partial apply.
+// The month the calendar is showing, and the four buttons that move it: back,
+// a native month picker behind a calendar icon, today, forward.
 
 import {computed, ref} from "vue"
+import UiButton from "../../../components/ui/UiButton.vue"
 
 const props = defineProps<{
   month: string
@@ -58,44 +58,39 @@ function onMonthInput(e: Event) {
 </script>
 
 <template>
-  <div class="row">
-    <div class="col-xs-12 col-md-6">
-      <h2>
-        <span>{{ monthLabel }}</span>
-        <small> ({{ businessDays }} {{ weekDaysLabel }}) </small>
-      </h2>
-    </div>
-    <div class="col-xs-12 col-md-6">
-      <div class="pull-right resource-nav">
-        <div class="btn-group btn-group-justified-responsive resource-nav">
-          <a class="btn btn-default" role="button" @click.prevent="emit('prev')">
-            <i class="fa fa-chevron-left" aria-hidden="true"></i>
-          </a>
-          <a class="btn btn-default month-picker-trigger" role="button" @click.prevent="openPicker">
-            <i class="fa fa-calendar" aria-hidden="true"></i>
-            <input
-              ref="hiddenInputRef"
-              type="month"
-              :value="monthInputValue"
-              class="month-picker-input"
-              tabindex="-1"
-              aria-hidden="true"
-              @change="onMonthInput"
-            />
-          </a>
-          <a
-            class="btn btn-default"
-            role="button"
-            :class="{disabled: isToday}"
-            @click.prevent="!isToday && emit('today')"
-          >
-            {{ todayLabel }}
-          </a>
-          <a class="btn btn-default" role="button" @click.prevent="emit('next')">
-            <i class="fa fa-chevron-right" aria-hidden="true"></i>
-          </a>
-        </div>
-      </div>
+  <div class="flex flex-wrap items-center justify-between gap-2">
+    <h2>
+      <span>{{ monthLabel }}</span>
+      <small> ({{ businessDays }} {{ weekDaysLabel }}) </small>
+    </h2>
+
+    <div class="bs-btn-group">
+      <UiButton as="a" role="button" @click.prevent="emit('prev')">
+        <i class="fa fa-chevron-left" aria-hidden="true"></i>
+      </UiButton>
+      <UiButton as="a" role="button" class="month-picker-trigger" @click.prevent="openPicker">
+        <i class="fa fa-calendar" aria-hidden="true"></i>
+        <input
+          ref="hiddenInputRef"
+          type="month"
+          :value="monthInputValue"
+          class="month-picker-input"
+          tabindex="-1"
+          aria-hidden="true"
+          @change="onMonthInput"
+        />
+      </UiButton>
+      <UiButton
+        as="a"
+        role="button"
+        :class="{'pointer-events-none opacity-65': isToday}"
+        @click.prevent="!isToday && emit('today')"
+      >
+        {{ todayLabel }}
+      </UiButton>
+      <UiButton as="a" role="button" @click.prevent="emit('next')">
+        <i class="fa fa-chevron-right" aria-hidden="true"></i>
+      </UiButton>
     </div>
   </div>
 </template>

--- a/app/frontend/islands/timers-calendar/components/TimerBadge.vue
+++ b/app/frontend/islands/timers-calendar/components/TimerBadge.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-// Renders the `<a class="timer">` chip from the legacy template
-// (`app/views/templates/timers/month.html.erb`). Variant classes
-// `billable` / `running` / `invoiced` are styled in
-// `app/assets/stylesheets/partials/_calendar.scss`.
+// The chip a booked timer becomes in a day of the calendar. What it is —
+// running, invoiced, billable — is the colour it carries.
 
 import {computed, onBeforeUnmount, onMounted, ref} from "vue"
 import {formatHHMM, runningDuration} from "../../../lib/timers/format"
@@ -11,10 +9,11 @@ import type {Timer} from "../../../lib/timers/types"
 const props = defineProps<{timer: Timer}>()
 defineEmits<{click: []}>()
 
-const variant = computed<"" | "billable" | "running" | "invoiced">(() => {
-  if (props.timer.started) return "running"
-  if (props.timer.positionId) return "invoiced"
-  if (props.timer.taskBillable) return "billable"
+const variant = computed(() => {
+  if (props.timer.started) return "is-running"
+  if (props.timer.positionId) return "is-invoiced"
+  if (props.timer.taskBillable) return "is-billable"
+
   return ""
 })
 
@@ -38,7 +37,7 @@ const display = computed(() => {
 </script>
 
 <template>
-  <a class="timer" role="button" :class="variant" @click.stop.prevent="$emit('click')">
+  <a class="bs-calendar-timer" role="button" :class="variant" @click.stop.prevent="$emit('click')">
     <span v-if="timer.started"
       ><i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i> {{ display }}</span
     >

--- a/app/frontend/islands/timers-calendar/components/TimerBadge.vue
+++ b/app/frontend/islands/timers-calendar/components/TimerBadge.vue
@@ -37,12 +37,17 @@ const display = computed(() => {
 </script>
 
 <template>
-  <a class="bs-calendar-timer" role="button" :class="variant" @click.stop.prevent="$emit('click')">
+  <button
+    type="button"
+    class="bs-calendar-timer"
+    :class="variant"
+    @click.stop="$emit('click')"
+  >
     <span v-if="timer.started"
       ><i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i> {{ display }}</span
     >
     <span v-else class="timer-value">{{ display }}</span>
     |
     <span class="timer-task" :title="timer.taskName">{{ timer.taskName }}</span>
-  </a>
+  </button>
 </template>

--- a/app/frontend/islands/timers-calendar/components/TimerModal.vue
+++ b/app/frontend/islands/timers-calendar/components/TimerModal.vue
@@ -223,9 +223,14 @@ watch(
             </label>
 
             <div v-if="!isInvoiced" class="mb-4">
-              <a v-if="!showCreateTask" role="button" @click.prevent="showCreateTask = true">
+              <UiButton
+                v-if="!showCreateTask"
+                variant="link"
+                class="px-0"
+                @click="showCreateTask = true"
+              >
                 + {{ t("timerModal.newTask") }}
-              </a>
+              </UiButton>
               <div v-else class="flex">
                 <UiInput
                   v-model="newTaskName"

--- a/app/frontend/islands/timers-calendar/components/TimerModal.vue
+++ b/app/frontend/islands/timers-calendar/components/TimerModal.vue
@@ -138,7 +138,7 @@ async function onStop() {
 
 async function onDelete() {
   if (!id.value) return
-  if (!(await confirmDialog("Diese Zeit löschen?"))) return
+  if (!(await confirmDialog(t("timerModal.confirmDelete")))) return
   saving.value = true
   try {
     await deleteTimer(id.value)
@@ -169,7 +169,7 @@ async function onCreateTask() {
 }
 
 function errorText(e: unknown): string {
-  return e instanceof Error ? e.message : "Etwas ist schiefgelaufen."
+  return e instanceof Error ? e.message : t("timerModal.failed")
 }
 
 watch(

--- a/app/frontend/islands/timers-calendar/components/TimerModal.vue
+++ b/app/frontend/islands/timers-calendar/components/TimerModal.vue
@@ -1,13 +1,18 @@
 <script setup lang="ts">
-// Bootstrap 3 modal markup — mirrors the legacy
-// `app/views/templates/timesheets/modal/timer.html.erb` so the
-// existing `.modal-*` and `.btn-*` styles apply.
+// Add / edit dialog for one day of a project's calendar. The timesheet's
+// modal is the same dialog for a screen that spans every project, so it picks
+// one; here the project is the one whose calendar is open.
 
 import {computed, onBeforeUnmount, onMounted, ref, watch} from "vue"
+import {useI18n} from "vue-i18n"
 import {formatHHMM, parseHHMM, runningDuration} from "../../../lib/timers/format"
 import {createTask, createTimer, deleteTimer, startTimer, stopTimer, updateTimer} from "../../../lib/timers/api"
 import type {Task, Timer} from "../../../lib/timers/types"
 import {confirmDialog} from "../../../lib/confirm"
+import UiButton from "../../../components/ui/UiButton.vue"
+import UiInput from "../../../components/ui/UiInput.vue"
+
+const {t} = useI18n()
 
 const props = defineProps<{
   draft: Partial<Timer> & {date: string; projectId: string}
@@ -44,7 +49,9 @@ const canPlay = computed(
   () => !isInvoiced.value && !isRunning.value && !!taskId.value && !saving.value,
 )
 
-const title = computed(() => (isEdit.value ? "Edit timer" : "Add timer"))
+const title = computed(() =>
+  isEdit.value ? t("timesheet.editTimer") : t("timesheet.addTimer"),
+)
 
 const now = ref(Date.now())
 let tickId: number | null = null
@@ -131,7 +138,7 @@ async function onStop() {
 
 async function onDelete() {
   if (!id.value) return
-  if (!(await confirmDialog("Delete this timer?"))) return
+  if (!(await confirmDialog("Diese Zeit löschen?"))) return
   saving.value = true
   try {
     await deleteTimer(id.value)
@@ -162,8 +169,7 @@ async function onCreateTask() {
 }
 
 function errorText(e: unknown): string {
-  if (e instanceof Error) return e.message
-  return "Something went wrong."
+  return e instanceof Error ? e.message : "Etwas ist schiefgelaufen."
 }
 
 watch(
@@ -176,158 +182,128 @@ watch(
 
 <template>
   <div>
-    <div class="modal-backdrop fade in"></div>
+    <div class="fixed inset-0 z-40 bg-ink/50"></div>
     <div
-      class="modal fade in"
+      class="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4"
       tabindex="-1"
       role="dialog"
       aria-modal="true"
-      style="display: block"
       @click.self="emit('close')"
     >
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <button class="close" type="button" aria-label="Close" @click="emit('close')">
+      <div class="relative z-50 mt-10 w-full max-w-lg" role="document">
+        <div class="bs-modal">
+          <div class="flex items-center justify-between border-b border-rule px-4 py-3.5">
+            <h3>{{ title }}</h3>
+            <button
+              type="button"
+              class="text-2xl leading-none opacity-20 hover:opacity-50"
+              :aria-label="t('timerModal.close')"
+              @click="emit('close')"
+            >
               <span aria-hidden="true">&times;</span>
             </button>
-            <h2 class="modal-title">{{ title }}</h2>
           </div>
 
-          <div class="modal-body">
-            <p v-if="isInvoiced" class="alert alert-success">
-              This timer is on an invoice and can't be changed.
+          <div class="px-4 py-3.5">
+            <p
+              v-if="isInvoiced"
+              class="mb-4 rounded-bs border border-alert-success-border bg-alert-success px-4 py-3.5 text-alert-success-text"
+            >
+              {{ t("timerModal.invoiced") }}
             </p>
 
-            <div class="row">
-              <div class="col-xs-12">
-                <select
-                  v-model="taskId"
-                  class="form-control"
-                  :disabled="isInvoiced"
+            <label class="mb-1 block">
+              <span class="mb-1 inline-block font-bold">{{ t("timerModal.task") }}</span>
+              <UiInput v-model="taskId" as="select" :disabled="isInvoiced">
+                <option value="">{{ t("timerModal.pickTask") }}</option>
+                <option v-for="task in localTasks" :key="task.id" :value="task.id">
+                  {{ task.name }}{{ task.billable ? ` (${t("timerModal.billable")})` : "" }}
+                </option>
+              </UiInput>
+            </label>
+
+            <div v-if="!isInvoiced" class="mb-4">
+              <a v-if="!showCreateTask" role="button" @click.prevent="showCreateTask = true">
+                + {{ t("timerModal.newTask") }}
+              </a>
+              <div v-else class="flex">
+                <UiInput
+                  v-model="newTaskName"
+                  class="rounded-r-none"
+                  :placeholder="t('timerModal.taskName')"
+                  @keydown.enter.prevent="onCreateTask"
+                />
+                <UiButton
+                  variant="primary"
+                  class="-ml-px rounded-none"
+                  :disabled="!newTaskName.trim() || saving"
+                  @click="onCreateTask"
                 >
-                  <option value="">— Select task —</option>
-                  <option v-for="task in localTasks" :key="task.id" :value="task.id">
-                    {{ task.name }}{{ task.billable ? " (billable)" : "" }}
-                  </option>
-                </select>
-
-                <div v-if="!isInvoiced" style="margin-top: 6px">
-                  <a v-if="!showCreateTask" role="button" @click.prevent="showCreateTask = true">
-                    <i class="fa fa-plus"></i> New task
-                  </a>
-                  <div v-else class="input-group">
-                    <input
-                      v-model="newTaskName"
-                      type="text"
-                      class="form-control"
-                      placeholder="New task name"
-                      @keydown.enter.prevent="onCreateTask"
-                    />
-                    <span class="input-group-btn">
-                      <button
-                        type="button"
-                        class="btn btn-primary"
-                        :disabled="!newTaskName.trim() || saving"
-                        @click="onCreateTask"
-                      >
-                        Create
-                      </button>
-                      <button
-                        type="button"
-                        class="btn btn-default"
-                        @click="showCreateTask = false"
-                      >
-                        Cancel
-                      </button>
-                    </span>
-                  </div>
-                </div>
-
-                <hr />
+                  {{ t("timerModal.createTask") }}
+                </UiButton>
+                <UiButton class="-ml-px rounded-l-none" @click="showCreateTask = false">
+                  {{ t("timerModal.cancel") }}
+                </UiButton>
               </div>
             </div>
 
-            <div class="row">
-              <div class="col-xs-12 col-md-8">
-                <textarea
+            <div class="grid grid-cols-12 items-start gap-2">
+              <div class="col-span-12 md:col-span-8">
+                <UiInput
                   v-model="note"
-                  class="form-control"
+                  as="textarea"
                   rows="3"
-                  placeholder="Note"
+                  :placeholder="t('timerModal.note')"
                   :disabled="isInvoiced"
-                ></textarea>
+                />
               </div>
-              <div class="col-xs-12 col-md-4">
-                <br class="visible-sm visible-xs" />
-                <div v-if="isRunning" class="modal-timer">
+
+              <div class="col-span-12 md:col-span-4">
+                <div v-if="isRunning" class="text-right text-[28px] text-brand">
                   {{ runningDisplay }}
                 </div>
-                <input
+                <UiInput
                   v-else
                   v-model="valueText"
-                  type="text"
-                  class="input-lg form-control text-right"
+                  class="h-[46px] text-right text-lg"
                   placeholder="0:00"
                   :disabled="isInvoiced"
                 />
               </div>
             </div>
 
-            <div class="row" v-if="!isInvoiced">
-              <div class="col-xs-12" style="margin-top: 10px">
-                <label class="control-label">Date</label>
-                <input
-                  v-model="date"
-                  type="date"
-                  class="form-control"
-                  :disabled="isRunning"
-                />
-              </div>
-            </div>
+            <label v-if="!isInvoiced" class="mt-4 block">
+              <span class="mb-1 inline-block font-bold">{{ t("timerModal.date") }}</span>
+              <UiInput v-model="date" type="date" :disabled="isRunning" />
+            </label>
 
-            <p v-if="errorMessage" class="alert alert-danger" style="margin-top: 12px">
+            <p
+              v-if="errorMessage"
+              class="mt-4 rounded-bs border border-alert-danger-border bg-alert-danger px-4 py-3.5 text-alert-danger-text"
+            >
               {{ errorMessage }}
             </p>
           </div>
 
-          <div class="modal-footer">
-            <div class="pull-left" v-if="canDelete">
-              <button type="button" class="btn btn-danger" @click="onDelete">
-                Delete
-              </button>
-            </div>
-            <div class="pull-right">
-              <button type="button" class="btn btn-default btn-lg" @click="emit('close')">
-                Cancel
-              </button>
-              <button
-                v-if="canStop"
-                type="button"
-                class="btn btn-default btn-lg"
-                title="Stop"
-                @click="onStop"
-              >
-                <i class="fa fa-stop"></i>
-              </button>
-              <button
-                v-if="canPlay"
-                type="button"
-                class="btn btn-default btn-lg"
-                title="Play"
-                @click="onPlay"
-              >
-                <i class="fa fa-play"></i>
-              </button>
-              <button
-                v-if="!isInvoiced"
-                type="button"
-                class="btn btn-primary btn-lg"
-                :disabled="!canSave"
-                @click="onSave"
-              >
-                Save
-              </button>
+          <div class="flex flex-wrap items-center gap-2 border-t border-rule px-4 py-3.5">
+            <UiButton v-if="canDelete" variant="danger" @click="onDelete">
+              {{ t("timerModal.delete") }}
+            </UiButton>
+
+            <div class="ml-auto flex flex-wrap gap-2">
+              <UiButton @click="emit('close')">{{ t("timerModal.cancel") }}</UiButton>
+
+              <UiButton v-if="canStop" :title="t('timerModal.stop')" @click="onStop">
+                <span aria-hidden="true">■</span>
+              </UiButton>
+
+              <UiButton v-if="canPlay" :title="t('timerModal.start')" @click="onPlay">
+                <span aria-hidden="true">▶</span>
+              </UiButton>
+
+              <UiButton v-if="!isInvoiced" variant="primary" :disabled="!canSave" @click="onSave">
+                {{ t("timerModal.save") }}
+              </UiButton>
             </div>
           </div>
         </div>

--- a/app/frontend/pages/projects/ProjectDetail.spec.ts
+++ b/app/frontend/pages/projects/ProjectDetail.spec.ts
@@ -8,10 +8,21 @@ import ProjectDetail from "./ProjectDetail.vue"
 import {AXIOS_INSTANCE} from "@/services/axiosClient"
 import {i18n} from "@/plugins/i18n"
 
-// Highcharts measures real SVG, which happy-dom does not implement; the
-// options it is handed are covered in `lib/projectBudgetChart.spec.ts`.
+// Highcharts measures real SVG, which happy-dom does not implement, so the
+// chart is a stub that keeps the options it was handed — what goes into them
+// is covered in `lib/projectBudgetChart.spec.ts`.
+let chartOptions: Record<string, unknown> | undefined
+
 vi.mock("@/lib/highcharts", () => ({
-  Highcharts: {Chart: class {destroy() {}}, setOptions() {}},
+  Highcharts: {
+    Chart: class {
+      constructor(options: Record<string, unknown>) {
+        chartOptions = options
+      }
+      destroy() {}
+    },
+    setOptions() {},
+  },
 }))
 
 const ID = "dddddddd-0000-4000-8000-000000000001"
@@ -186,6 +197,18 @@ describe("ProjectDetail", () => {
 
     expect(offers?.params?.project_id).toBe(ID)
     expect(invoices?.params?.project_id).toBe(ID)
+  })
+
+  // The axis is labelled with the month's short name and nothing else: the
+  // label has to fit the width of that month on the axis, and month plus year
+  // wrapped onto a second line that the chart then cut off.
+  it("labels the chart's axis with the short month", async () => {
+    await mountDetail()
+
+    const xAxis = chartOptions?.xAxis as {categories: {short: string; long: string}[]}
+
+    expect(xAxis.categories[0].short).toBe("Jan")
+    expect(xAxis.categories[0].long).toBe("January")
   })
 
   it("says so where a tab has nothing in it", async () => {

--- a/app/frontend/pages/projects/ProjectDetail.vue
+++ b/app/frontend/pages/projects/ProjectDetail.vue
@@ -173,24 +173,6 @@ async function refresh(): Promise<void> {
   ])
 }
 
-const timerLabels = computed(() => ({
-  weekDays: t("projectDetail.timers.weekDays"),
-  today: t("projectDetail.timers.today"),
-  addTimer: t("projectDetail.timers.addTimer"),
-  dayShort: Array.from({ length: 7 }, (_, index) =>
-    new Intl.DateTimeFormat(locale.value, { weekday: "short", timeZone: "UTC" }).format(
-      new Date(Date.UTC(2024, 0, 1 + index)),
-    ),
-  ),
-}))
-
-const monthLabels = computed(() =>
-  Array.from({ length: 12 }, (_, index) =>
-    new Intl.DateTimeFormat(locale.value, { month: "long", timeZone: "UTC" }).format(
-      new Date(Date.UTC(2024, index, 1)),
-    ),
-  ),
-)
 </script>
 
 <template>
@@ -297,8 +279,6 @@ const monthLabels = computed(() =>
             v-if="active === 'timers'"
             :key="id"
             :project-id="id"
-            :labels="timerLabels"
-            :month-labels="monthLabels"
             data-test="timers-calendar"
             @changed="refresh"
           />

--- a/app/frontend/pages/projects/ProjectDetail.vue
+++ b/app/frontend/pages/projects/ProjectDetail.vue
@@ -85,6 +85,15 @@ const dates = computed(
       timeZone: "UTC",
     }),
 )
+// The chart's own labels: `%b` along the axis, `%B` behind it, as
+// `date.formats.month_short` and `month` gave Highcharts. The year is not in
+// them — a month's name has to fit the width of that month on the axis.
+const shortMonths = computed(
+  () => new Intl.DateTimeFormat(locale.value, { month: "short", timeZone: "UTC" }),
+)
+const longMonths = computed(
+  () => new Intl.DateTimeFormat(locale.value, { month: "long", timeZone: "UTC" }),
+)
 
 function amount(value: string | number | null | undefined): string {
   return money.value.format(Number(value ?? 0))
@@ -147,8 +156,8 @@ const build = computed(() => {
       formatValue: (value: number) => money.value.format(value),
       // `invoicesChart`'s formatter, which this chart shares.
       formatAxis: (value: number) => (value < 1000 ? `${value} €` : `${value / 1000}k €`),
-      monthShort: (label) => months.value.format(new Date(`${label.slice(0, 10)}T00:00:00Z`)),
-      monthLong: weekOf,
+      monthShort: (label) => shortMonths.value.format(new Date(`${label.slice(0, 10)}T00:00:00Z`)),
+      monthLong: (label) => longMonths.value.format(new Date(`${label.slice(0, 10)}T00:00:00Z`)),
       dateLabel: weekOf,
       budgetLabel: (formatted) => t("projectDetail.budgetEstimate", { amount: formatted }),
       onPointOver: highlight,

--- a/app/frontend/pages/projects/ProjectDetail.vue
+++ b/app/frontend/pages/projects/ProjectDetail.vue
@@ -290,7 +290,6 @@ const monthLabels = computed(() =>
             :project-id="id"
             :labels="timerLabels"
             :month-labels="monthLabels"
-            :standalone="false"
             data-test="timers-calendar"
             @changed="refresh"
           />

--- a/app/frontend/pages/timesheet/components/DayView.vue
+++ b/app/frontend/pages/timesheet/components/DayView.vue
@@ -31,7 +31,9 @@ defineExpose({refresh})
         class="mb-2.5 rounded-bs border border-alert-danger-border bg-alert-danger px-4 py-3.5 text-alert-danger-text"
       >
         {{ t("timesheet.timersFailed") }}
-        <a role="button" @click.prevent="refresh">{{ t("timesheet.retry") }}</a>
+        <UiButton variant="link" class="px-0" @click="refresh">
+          {{ t("timesheet.retry") }}
+        </UiButton>
       </div>
 
       <p v-if="loading && timers.length === 0" class="text-muted">{{ t("timesheet.loading") }}</p>

--- a/app/frontend/pages/timesheet/components/TaskModal.vue
+++ b/app/frontend/pages/timesheet/components/TaskModal.vue
@@ -156,9 +156,14 @@ function onSave() {
               </label>
 
               <div v-if="projectId" class="mb-4">
-                <a v-if="!showCreate" role="button" @click.prevent="showCreate = true">
+                <UiButton
+                  v-if="!showCreate"
+                  variant="link"
+                  class="px-0"
+                  @click="showCreate = true"
+                >
                   + {{ t("timerModal.newTask") }}
-                </a>
+                </UiButton>
                 <div v-else class="flex">
                   <UiInput
                     v-model="newTaskName"

--- a/app/frontend/pages/timesheet/components/TimerModal.vue
+++ b/app/frontend/pages/timesheet/components/TimerModal.vue
@@ -261,9 +261,14 @@ function errorText(e: unknown): string {
               </label>
 
               <div v-if="projectId && !isInvoiced" class="mb-4">
-                <a v-if="!showCreateTask" role="button" @click.prevent="showCreateTask = true">
+                <UiButton
+                  v-if="!showCreateTask"
+                  variant="link"
+                  class="px-0"
+                  @click="showCreateTask = true"
+                >
                   + {{ t("timerModal.newTask") }}
-                </a>
+                </UiButton>
                 <div v-else class="flex">
                   <UiInput
                     v-model="newTaskName"

--- a/app/frontend/pages/timesheet/components/TimerModal.vue
+++ b/app/frontend/pages/timesheet/components/TimerModal.vue
@@ -167,7 +167,7 @@ async function onStop() {
 
 async function onDelete() {
   if (!id.value) return
-  if (!(await confirmDialog("Diese Zeit löschen?"))) return
+  if (!(await confirmDialog(t("timerModal.confirmDelete")))) return
   saving.value = true
   try {
     await deleteTimer(id.value)
@@ -201,7 +201,7 @@ async function onCreateTaskInline() {
 }
 
 function errorText(e: unknown): string {
-  return e instanceof Error ? e.message : "Etwas ist schiefgelaufen."
+  return e instanceof Error ? e.message : t("timerModal.failed")
 }
 </script>
 

--- a/app/frontend/pages/timesheet/components/WeekGrid.vue
+++ b/app/frontend/pages/timesheet/components/WeekGrid.vue
@@ -130,7 +130,9 @@ async function onTaskRemove(task: TaskWithTimers) {
   <div class="mt-3" data-test="week-grid">
     <div v-if="error" class="mb-2.5 rounded-bs border border-alert-danger-border bg-alert-danger px-4 py-3.5 text-alert-danger-text">
       {{ t("timesheet.tasksFailed") }}
-      <a role="button" @click.prevent="refresh">{{ t("timesheet.retry") }}</a>
+      <UiButton variant="link" class="px-0" @click="refresh">
+        {{ t("timesheet.retry") }}
+      </UiButton>
     </div>
 
     <div class="grid grid-cols-12 items-end gap-2 px-4 py-1.5">

--- a/app/frontend/translations/de.ts
+++ b/app/frontend/translations/de.ts
@@ -284,6 +284,8 @@ export default {
     save: "Speichern",
     start: "Start",
     stop: "Stopp",
+    confirmDelete: "Diese Zeit löschen?",
+    failed: "Etwas ist schiefgelaufen.",
   },
   timesheet: {
     timersFailed: "Zeiten konnten nicht geladen werden.",

--- a/app/frontend/translations/de.ts
+++ b/app/frontend/translations/de.ts
@@ -265,6 +265,11 @@ export default {
   taskModal: {
     add: "Hinzufügen",
   },
+  timersCalendar: {
+    weekDays: "Arbeitstage",
+    today: "Heute",
+    addTimer: "Zeit erfassen",
+  },
   timerModal: {
     close: "Schließen",
     invoiced: "Diese Zeit wurde bereits abgerechnet und kann nicht geändert werden.",
@@ -333,11 +338,6 @@ export default {
       offers: "Angebote",
       invoices: "Rechnungen",
       tasks: "Aufgaben",
-    },
-    timers: {
-      weekDays: "Arbeitstage",
-      today: "Heute",
-      addTimer: "Zeit erfassen",
     },
   },
   projects: {

--- a/app/frontend/translations/en.ts
+++ b/app/frontend/translations/en.ts
@@ -265,6 +265,11 @@ export default {
   taskModal: {
     add: "Add",
   },
+  timersCalendar: {
+    weekDays: "Working days",
+    today: "Today",
+    addTimer: "Track time",
+  },
   timerModal: {
     close: "Close",
     invoiced: "This time is on an invoice already and cannot be changed.",
@@ -333,11 +338,6 @@ export default {
       offers: "Offers",
       invoices: "Invoices",
       tasks: "Tasks",
-    },
-    timers: {
-      weekDays: "Working days",
-      today: "Today",
-      addTimer: "Track time",
     },
   },
   projects: {

--- a/app/frontend/translations/en.ts
+++ b/app/frontend/translations/en.ts
@@ -284,6 +284,8 @@ export default {
     save: "Save",
     start: "Start",
     stop: "Stop",
+    confirmDelete: "Delete this time?",
+    failed: "Something went wrong.",
   },
   timesheet: {
     timersFailed: "The times could not be loaded.",

--- a/test/e2e/TimersCalendar.spec.ts
+++ b/test/e2e/TimersCalendar.spec.ts
@@ -16,9 +16,8 @@ test.describe("Timers calendar", () => {
     await expect(page.getByTestId("dashboard-greeting")).toBeVisible()
   })
 
-  // It lives on the project detail page, which is still server-rendered: the
-  // offers and invoices panels around it belong to B6 and B7.
-  test("renders on the server-rendered project page", async ({ page }) => {
+  // It lives on the project detail screen, which the old path forwards to.
+  test("renders on the project screen the old path forwards to", async ({ page }) => {
     const id = (await appEval(`Project.first.id`)) as string
 
     await page.goto(`/projects/${id}`)
@@ -38,6 +37,24 @@ test.describe("Timers calendar", () => {
     await expect(calendar).toBeVisible()
 
     await expect(calendar.locator(".timer-value")).toHaveText("1:00")
+  })
+
+  // The calendar was styled by the server-rendered bundle until the project
+  // screen moved; with only `spa.css` loaded its grid collapsed into one long
+  // column of day numbers.
+  test("lays a week out as seven columns", async ({ page }) => {
+    const id = (await appEval(`Project.first.id`)) as string
+
+    await page.goto(`/projects/${id}`)
+
+    const days = page.locator(".bs-calendar-week").first().locator(".bs-calendar-day")
+    await expect(days).toHaveCount(7)
+
+    const first = await days.first().boundingBox()
+    const last = await days.last().boundingBox()
+
+    expect(first?.y).toBe(last?.y)
+    expect(last?.x).toBeGreaterThan((first?.x ?? 0) + (first?.width ?? 0) * 5)
   })
 
   test("shows the month the timers were tracked in", async ({ page }) => {


### PR DESCRIPTION
Follow-up to #1013, which moved the project screen but left the calendar on it
looking broken.

The calendar was written as an island on a server-rendered screen, so its
grid, its chips, its month navigation and its dialog were all styled by the
Bootstrap bundle that screen loads. Inside the SPA, where only `spa.css`
applies, it collapsed into one long column of day numbers with unstyled links
— and the dialog would have been just as bare.

- `partials/_calendar.scss` is measured into `spa.css` as `.bs-calendar*`:
  seven columns to a week, hundred-pixel cells, the neighbouring months in
  grey, today in `lighten($brand-primary, 30%)`, and the timer chips in grey /
  info / amber / green by what the timer is.
- The four components now use what the SPA has: `UiButton` for the month
  navigation, `UiAlert` for a failed load, and the timesheet dialog's markup
  and `timerModal.*` copy for the timer dialog — which was also the last
  English text on the screen ("Add timer", "This timer is on an invoice and
  can't be changed", "Save").
- The project screen was the calendar's only server-rendered host, so it
  leaves the island registry with it. With nothing left to reload, the
  `standalone` branch goes too: it always tells the screen around it.
- `.bs-progress-bar` gets back the inset shadow along its lower edge and the
  width transition Bootstrap's `.progress-bar` had.

Measured against the old stylesheet rather than guessed: `.chart-big` never
existed there (only a `.chart-dashboard` selector that could not match), so
both charts stay at 400px, and `progress-slim` really is 14px.

New e2e guard: a week lays out as seven columns in one row — exactly the break
that got through. 261 vitest, e2e green, `vue-tsc` clean.

Note for later: this dialog and `pages/timesheet/components/TimerModal.vue`
are now the same dialog twice, one with a project select and one without.
Worth folding together, but not inside a fix. 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed timers calendar experience with improved navigation, day links, timer status indicators, and calendar controls.
  * Added localized loading, error, modal, and confirmation text.
  * Updated timer dialogs with consistent UI controls and styling.
* **Improvements**
  * Calendar layouts now display weeks consistently across seven columns.
  * Added Bootstrap-compatible styling for calendars, progress bars, hover states, and timer indicators.
* **Bug Fixes**
  * Calendar updates now refresh timer data after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->