### PR TITLE
feat(api): report and change the accounts an admin manages

### DIFF
--- a/app/api_components/v1/schemas/backend_account.rb
+++ b/app/api_components/v1/schemas/backend_account.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    # Admin-facing view of an account: what the backend list and form show,
+    # which is the plan, the feature flags and who is on it.
+    class BackendAccount
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          id: {type: :string, format: :uuid},
+          name: {type: :string},
+          subdomain: {type: [:string, :null]},
+          plan: {type: :string},
+          featureExpenses: {type: :boolean},
+          featureLogbook: {type: :boolean},
+          usersCount: {type: :integer},
+          trialEndAt: {type: [:string, :null], format: "date-time"},
+          createdAt: {type: :string, format: "date-time"},
+          updatedAt: {type: :string, format: "date-time"}
+        },
+        additionalProperties: false,
+        required: %w[id name plan featureExpenses featureLogbook usersCount createdAt updatedAt]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/backend_account.rb
+++ b/app/api_components/v1/schemas/backend_account.rb
@@ -13,7 +13,9 @@ module V1
           id: {type: :string, format: :uuid},
           name: {type: :string},
           subdomain: {type: [:string, :null]},
-          plan: {type: :string},
+          # The column is nullable — the presence validation covers what goes
+          # in through the app, not a row that predates it.
+          plan: {type: [:string, :null]},
           featureExpenses: {type: :boolean},
           featureLogbook: {type: :boolean},
           usersCount: {type: :integer},

--- a/app/api_components/v1/schemas/backend_accounts.rb
+++ b/app/api_components/v1/schemas/backend_accounts.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class BackendAccounts
+      include OpenapiRuby::Components::Base
+
+      schema({type: :array, items: V1::Schemas::BackendAccount})
+    end
+  end
+end

--- a/app/api_components/v1/schemas/inputs/backend_account_create_input.rb
+++ b/app/api_components/v1/schemas/inputs/backend_account_create_input.rb
@@ -3,21 +3,22 @@
 module V1
   module Schemas
     module Inputs
-      # What an update takes. Creating also needs the first user's address,
-      # which `BackendAccountCreateInput` requires — sharing one schema would
-      # mean either an update that demands an email or a create that does not.
-      class BackendAccountInput
+      # `email` is the first user the account gets: an account is invalid
+      # without one, so creating takes both or neither.
+      class BackendAccountCreateInput
         include OpenapiRuby::Components::Base
 
         schema({
           type: :object,
           properties: {
             name: {type: :string},
+            email: {type: :string},
             plan: {type: :string},
             feature_expenses: {type: :boolean},
             feature_logbook: {type: :boolean}
           },
-          additionalProperties: false
+          additionalProperties: false,
+          required: %w[name email]
         })
       end
     end

--- a/app/api_components/v1/schemas/inputs/backend_account_input.rb
+++ b/app/api_components/v1/schemas/inputs/backend_account_input.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class BackendAccountInput
+        include OpenapiRuby::Components::Base
+
+        # `email` is the first user the account gets, which is how the backend
+        # creates one — the account is invalid without a user. It is ignored on
+        # an update, where the users are managed on their own screen.
+        schema({
+          type: :object,
+          properties: {
+            name: {type: :string},
+            email: {type: :string},
+            plan: {type: :string},
+            feature_expenses: {type: :boolean},
+            feature_logbook: {type: :boolean}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/backend/accounts_controller.rb
+++ b/app/controllers/api/v1/backend/accounts_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Backend
+      class AccountsController < BaseController
+        rescue_from ActiveRecord::RecordNotFound do |_exception|
+          not_found(I18n.t("messages.record_not_found.base"))
+        end
+
+        after_action -> { pagination_header(:accounts) }, only: [:index]
+
+        def index
+          @accounts = paginate(::Account.includes(:users).order(created_at: :desc))
+        end
+
+        def show
+          @account = ::Account.find(params[:id])
+        end
+
+        # Mirrors the web flow: an account cannot exist without a user, so the
+        # first one comes with it and is mailed a confirmation to pick their
+        # own password.
+        def create
+          attributes = account_params
+          @account = ::Account.new(attributes.except(:email).reverse_merge(plan: "free"))
+          @account.users.build(email: attributes[:email], created_via_admin: true, password: generated_password)
+
+          if @account.save
+            render :show, status: :created
+          else
+            render json: ValidationError.new("account.create", @account.errors), status: :bad_request
+          end
+        end
+
+        def update
+          @account = ::Account.find(params[:id])
+
+          return render :show if @account.update(account_params.except(:email))
+
+          render json: ValidationError.new("account.update", @account.errors), status: :bad_request
+        end
+
+        def destroy
+          @account = ::Account.find(params[:id])
+
+          if @account.destroy
+            render json: {message: resource_message(:account, :destroy, :success)}
+          else
+            render json: ValidationError.new("account.destroy", @account.errors), status: :bad_request
+          end
+        end
+
+        private def generated_password
+          @generated_password ||= Devise.friendly_token.first(16)
+        end
+
+        private def account_params
+          openapi_params(::V1::Schemas::Inputs::BackendAccountInput)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/backend/accounts_controller.rb
+++ b/app/controllers/api/v1/backend/accounts_controller.rb
@@ -11,7 +11,7 @@ module Api
         after_action -> { pagination_header(:accounts) }, only: [:index]
 
         def index
-          @accounts = paginate(::Account.includes(:users).order(created_at: :desc))
+          @accounts = paginate(::Account.includes(:users).order(created_at: :desc, id: :desc))
         end
 
         def show

--- a/app/controllers/api/v1/backend/accounts_controller.rb
+++ b/app/controllers/api/v1/backend/accounts_controller.rb
@@ -22,7 +22,7 @@ module Api
         # first one comes with it and is mailed a confirmation to pick their
         # own password.
         def create
-          attributes = account_params
+          attributes = create_params
           @account = ::Account.new(attributes.except(:email).reverse_merge(plan: "free"))
           @account.users.build(email: attributes[:email], created_via_admin: true, password: generated_password)
 
@@ -36,7 +36,7 @@ module Api
         def update
           @account = ::Account.find(params[:id])
 
-          return render :show if @account.update(account_params.except(:email))
+          return render :show if @account.update(account_params)
 
           render json: ValidationError.new("account.update", @account.errors), status: :bad_request
         end
@@ -53,6 +53,10 @@ module Api
 
         private def generated_password
           @generated_password ||= Devise.friendly_token.first(16)
+        end
+
+        private def create_params
+          openapi_params(::V1::Schemas::Inputs::BackendAccountCreateInput)
         end
 
         private def account_params

--- a/app/controllers/api/v1/backend/users_controller.rb
+++ b/app/controllers/api/v1/backend/users_controller.rb
@@ -11,7 +11,7 @@ module Api
         after_action -> { pagination_header(:users) }, only: [:index]
 
         def index
-          @users = paginate(::User.all.order(created_at: :desc))
+          @users = paginate(::User.all.order(created_at: :desc, id: :desc))
         end
 
         def show

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -26,6 +26,7 @@ class Account < ApplicationRecord
   accepts_nested_attributes_for :users
 
   before_save :calculate_office_percent
+  before_save :clear_trial_on_free_plan
   before_create :start_trial
 
   def uninvoiced_amount
@@ -74,6 +75,18 @@ class Account < ApplicationRecord
 
     self.trial_used = true
     self.trial_end_at = TRIAL_LENGTH.from_now
+  end
+
+  # `trial_expired?` reads `trial_end_at` alone, so an account moved onto the
+  # free plan while carrying a date in the past would go read-only on a plan
+  # that is not supposed to have a trial at all. Moving the other way is
+  # deliberately not the mirror image: whether an upgrade grants a fresh
+  # fortnight is a decision, not a consequence.
+  private def clear_trial_on_free_plan
+    return unless on_plan?(:free)
+    return if trial_end_at.nil?
+
+    self.trial_end_at = nil
   end
 
   def trial?

--- a/app/views/api/v1/backend/accounts/_show.json.jbuilder
+++ b/app/views/api/v1/backend/accounts/_show.json.jbuilder
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+json.id account.id
+json.name account.name
+json.subdomain account.subdomain
+json.plan account.plan
+json.feature_expenses account.feature_expenses?
+json.feature_logbook account.feature_logbook?
+json.users_count account.users.size
+json.trial_end_at account.trial_end_at
+json.created_at account.created_at
+json.updated_at account.updated_at

--- a/app/views/api/v1/backend/accounts/index.json.jbuilder
+++ b/app/views/api/v1/backend/accounts/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! partial: "api/v1/backend/accounts/show", collection: @accounts, as: :account

--- a/app/views/api/v1/backend/accounts/show.json.jbuilder
+++ b/app/views/api/v1/backend/accounts/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/backend/accounts/show", account: @account

--- a/config/routes/api_v1_routes.rb
+++ b/config/routes/api_v1_routes.rb
@@ -31,6 +31,8 @@ v1_api_routes = lambda do
   resource :dashboard, only: %i[show], controller: :dashboard
 
   namespace :backend do
+    resources :accounts, only: %i[index show create update destroy]
+
     resources :users, only: %i[index show create update destroy] do
       member do
         post :send_welcome

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -81,6 +81,195 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/backend/accounts":
+    get:
+      summary: Every account
+      tags:
+      - Backend
+      operationId: backendAccounts
+      parameters:
+      - "$ref": "#/components/parameters/PageParameter"
+      - "$ref": "#/components/parameters/PerPageParameter"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BackendAccounts"
+          headers:
+            Link:
+              description: RFC 8288 pagination links.
+              schema:
+                type: string
+        '403':
+          description: not an admin
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    post:
+      summary: Create an account, with the user it cannot exist without
+      tags:
+      - Backend
+      operationId: createBackendAccount
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BackendAccountInput"
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BackendAccount"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '403':
+          description: not an admin
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+  "/backend/accounts/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: Get an account
+      tags:
+      - Backend
+      operationId: backendAccount
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BackendAccount"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: not an admin
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    patch:
+      summary: Update an account
+      tags:
+      - Backend
+      operationId: updateBackendAccount
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BackendAccountInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BackendAccount"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: not an admin
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+    delete:
+      summary: Destroy an account
+      tags:
+      - Backend
+      operationId: destroyBackendAccount
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Message"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: not an admin
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/backend/users":
     get:
       summary: Users across every account
@@ -3164,6 +3353,68 @@ components:
       - registrationEnabled
       - domain
       title: AppConfig
+    BackendAccount:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        subdomain:
+          type:
+          - string
+          - 'null'
+        plan:
+          type: string
+        featureExpenses:
+          type: boolean
+        featureLogbook:
+          type: boolean
+        usersCount:
+          type: integer
+        trialEndAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - name
+      - plan
+      - featureExpenses
+      - featureLogbook
+      - usersCount
+      - createdAt
+      - updatedAt
+      title: BackendAccount
+    BackendAccountInput:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        plan:
+          type: string
+        feature_expenses:
+          type: boolean
+        feature_logbook:
+          type: boolean
+      additionalProperties: false
+      title: BackendAccountInput
+    BackendAccounts:
+      type: array
+      items:
+        "$ref": "#/components/schemas/BackendAccount"
+      title: BackendAccounts
     BackendUser:
       type: object
       properties:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -126,7 +126,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/BackendAccountInput"
+              "$ref": "#/components/schemas/BackendAccountCreateInput"
       responses:
         '201':
           description: successful
@@ -3366,7 +3366,9 @@ components:
           - string
           - 'null'
         plan:
-          type: string
+          type:
+          - string
+          - 'null'
         featureExpenses:
           type: boolean
         featureLogbook:
@@ -3395,12 +3397,28 @@ components:
       - createdAt
       - updatedAt
       title: BackendAccount
-    BackendAccountInput:
+    BackendAccountCreateInput:
       type: object
       properties:
         name:
           type: string
         email:
+          type: string
+        plan:
+          type: string
+        feature_expenses:
+          type: boolean
+        feature_logbook:
+          type: boolean
+      additionalProperties: false
+      required:
+      - name
+      - email
+      title: BackendAccountCreateInput
+    BackendAccountInput:
+      type: object
+      properties:
+        name:
           type: string
         plan:
           type: string

--- a/test/integration/api/v1/backend_account_test.rb
+++ b/test/integration/api/v1/backend_account_test.rb
@@ -117,6 +117,18 @@ module Api
           assert account.reload.feature_expenses
         end
 
+        # A free plan has no trial, so the date a paid plan left behind has to
+        # go with it — `trial_expired?` reads that column alone.
+        it "drops the trial when an account is moved to the free plan" do
+          account.update_columns(plan: "basic", trial_used: true, trial_end_at: 1.minute.ago)
+
+          assert_api_response :patch, 200, path_params: {id: account.id}, body: {plan: "free"} do
+            assert_nil parsed_body["trialEndAt"]
+          end
+
+          refute account.reload.trial_expired?
+        end
+
         it "refuses a name that is not there" do
           assert_api_response :patch, 400, path_params: {id: account.id}, body: {name: ""} do
             assert_equal "validation_error.account.update", parsed_body["code"]

--- a/test/integration/api/v1/backend_account_test.rb
+++ b/test/integration/api/v1/backend_account_test.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+module Api
+  module V1
+    class BackendAccountTest < ActionDispatch::IntegrationTest
+      include OpenapiRuby::Adapters::Minitest::DSL
+
+      openapi_schema :"v1/schema"
+
+      api_path "/backend/accounts/{id}" do
+        parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, required: true
+
+        get("Get an account") do
+          operationId "backendAccount"
+          tags "Backend"
+          produces "application/json"
+
+          response(200, "successful") do
+            schema ::V1::Schemas::BackendAccount
+          end
+
+          response(404, "not found") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(403, "not an admin") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(401, "unauthorized") do
+            schema ::V1::Schemas::StandardError
+          end
+        end
+
+        patch("Update an account") do
+          operationId "updateBackendAccount"
+          tags "Backend"
+          consumes "application/json"
+          produces "application/json"
+
+          request_body required: true, content: {
+            "application/json" => {schema: ::V1::Schemas::Inputs::BackendAccountInput}
+          }
+
+          response(200, "successful") do
+            schema ::V1::Schemas::BackendAccount
+          end
+
+          response(400, "bad request") do
+            schema ::V1::Schemas::ValidationError
+          end
+
+          response(404, "not found") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(403, "not an admin") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(401, "unauthorized") do
+            schema ::V1::Schemas::StandardError
+          end
+        end
+
+        delete("Destroy an account") do
+          operationId "destroyBackendAccount"
+          tags "Backend"
+          produces "application/json"
+
+          response(200, "successful") do
+            schema ::V1::Schemas::Message
+          end
+
+          response(400, "bad request") do
+            schema ::V1::Schemas::ValidationError
+          end
+
+          response(404, "not found") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(403, "not an admin") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(401, "unauthorized") do
+            schema ::V1::Schemas::StandardError
+          end
+        end
+      end
+
+      let(:admin) { users :jeanluc }
+      let(:account) { accounts :enterprise }
+
+      describe "as an admin" do
+        before { sign_in admin }
+
+        it "shows an account" do
+          assert_api_response :get, 200, path_params: {id: account.id} do
+            assert_equal account.name, parsed_body["name"]
+            assert_equal account.users.count, parsed_body["usersCount"]
+          end
+        end
+
+        # The two features the backend form switches, and the plan.
+        it "switches a feature on" do
+          account.update_columns(feature_expenses: false)
+
+          assert_api_response :patch, 200, path_params: {id: account.id},
+            body: {feature_expenses: true} do
+            assert parsed_body["featureExpenses"]
+          end
+
+          assert account.reload.feature_expenses
+        end
+
+        it "refuses a name that is not there" do
+          assert_api_response :patch, 400, path_params: {id: account.id}, body: {name: ""} do
+            assert_equal "validation_error.account.update", parsed_body["code"]
+          end
+        end
+
+        # An account takes everything on it with it, which is why the backend
+        # is the only place this is offered.
+        it "destroys an account" do
+          other = Account.create!(
+            name: "Vulcan Science Academy", plan: "free",
+            users: [User.new(email: "spock@vulcan.gov", password: "long-enough-password")]
+          )
+
+          assert_api_response :delete, 200, path_params: {id: other.id}
+
+          assert_nil Account.find_by(id: other.id)
+        end
+
+        it "is not found for an unknown id" do
+          assert_api_response :get, 404, path_params: {id: SecureRandom.uuid}
+        end
+      end
+
+      it "is forbidden for a non-admin" do
+        sign_in users(:data)
+
+        assert_api_response :get, 403, path_params: {id: account.id}
+      end
+
+      it "is unauthorized when signed out" do
+        assert_api_response :get, 401, path_params: {id: account.id}
+      end
+    end
+  end
+end

--- a/test/integration/api/v1/backend_accounts_test.rb
+++ b/test/integration/api/v1/backend_accounts_test.rb
@@ -39,7 +39,7 @@ module Api
           produces "application/json"
 
           request_body required: true, content: {
-            "application/json" => {schema: ::V1::Schemas::Inputs::BackendAccountInput}
+            "application/json" => {schema: ::V1::Schemas::Inputs::BackendAccountCreateInput}
           }
 
           response(201, "successful") do
@@ -100,9 +100,11 @@ module Api
           assert User.find_by(email: "spock@vulcan.gov").created_via_admin
         end
 
-        it "refuses an account without a user" do
+        # The schema asks for an address; an empty one gets as far as the
+        # model, which will not have an account without a user either.
+        it "refuses an account whose user has no address" do
           assert_no_difference "Account.count" do
-            assert_api_response :post, 400, body: {name: "Nowhere"} do
+            assert_api_response :post, 400, body: {name: "Nowhere", email: ""} do
               assert_equal "validation_error.account.create", parsed_body["code"]
             end
           end

--- a/test/integration/api/v1/backend_accounts_test.rb
+++ b/test/integration/api/v1/backend_accounts_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+module Api
+  module V1
+    class BackendAccountsTest < ActionDispatch::IntegrationTest
+      include OpenapiRuby::Adapters::Minitest::DSL
+
+      openapi_schema :"v1/schema"
+
+      api_path "/backend/accounts" do
+        get("Every account") do
+          operationId "backendAccounts"
+          tags "Backend"
+          produces "application/json"
+
+          parameter "$ref": "#/components/parameters/PageParameter"
+          parameter "$ref": "#/components/parameters/PerPageParameter"
+
+          response(200, "successful") do
+            schema ::V1::Schemas::BackendAccounts
+            header "Link", schema: {type: :string}, description: "RFC 8288 pagination links."
+          end
+
+          response(403, "not an admin") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(401, "unauthorized") do
+            schema ::V1::Schemas::StandardError
+          end
+        end
+
+        post("Create an account, with the user it cannot exist without") do
+          operationId "createBackendAccount"
+          tags "Backend"
+          consumes "application/json"
+          produces "application/json"
+
+          request_body required: true, content: {
+            "application/json" => {schema: ::V1::Schemas::Inputs::BackendAccountInput}
+          }
+
+          response(201, "successful") do
+            schema ::V1::Schemas::BackendAccount
+          end
+
+          response(400, "bad request") do
+            schema ::V1::Schemas::ValidationError
+          end
+
+          response(403, "not an admin") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(401, "unauthorized") do
+            schema ::V1::Schemas::StandardError
+          end
+        end
+      end
+
+      let(:admin) { users :jeanluc }
+      let(:member) { users :data }
+
+      it "is unauthorized when signed out" do
+        assert_api_response :get, 401
+      end
+
+      it "is forbidden for a non-admin" do
+        sign_in member
+
+        assert_api_response :get, 403 do
+          assert_equal "forbidden", parsed_body["code"]
+        end
+      end
+
+      describe "as an admin" do
+        before { sign_in admin }
+
+        it "lists every account, newest first, with what the list shows" do
+          assert_api_response :get, 200, params: {perPage: "all"} do
+            names = parsed_body.map { |account| account["name"] }
+
+            assert_includes names, accounts(:enterprise).name
+            assert_operator parsed_body.first["usersCount"], :>=, 1
+          end
+        end
+
+        # The account is invalid without a user, so the first one comes with
+        # it — and is mailed a confirmation to pick their own password.
+        it "creates an account together with its first user" do
+          assert_difference ["Account.count", "User.count"], 1 do
+            assert_api_response :post, 201, body: {name: "Vulcan Science Academy", email: "spock@vulcan.gov"} do
+              assert_equal "free", parsed_body["plan"]
+              assert_equal 1, parsed_body["usersCount"]
+            end
+          end
+
+          assert User.find_by(email: "spock@vulcan.gov").created_via_admin
+        end
+
+        it "refuses an account without a user" do
+          assert_no_difference "Account.count" do
+            assert_api_response :post, 400, body: {name: "Nowhere"} do
+              assert_equal "validation_error.account.create", parsed_body["code"]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -42,6 +42,29 @@ class AccountTest < ActiveSupport::TestCase
     end
   end
 
+  # `trial_expired?` reads `trial_end_at` alone, so a date left behind on a
+  # free account turns every screen read-only on a plan that has no trial.
+  describe "moving onto the free plan" do
+    it "drops the trial the paid plan carried" do
+      account = build_account(plan: "basic")
+      account.save!
+      account.update!(plan: "free")
+
+      refute account.reload.trial?
+      refute account.trial_expired?
+    end
+
+    it "keeps a paid plan's trial where it is" do
+      account = build_account(plan: "basic")
+      account.save!
+      ending = account.trial_end_at
+
+      account.update!(name: "Stargazer II")
+
+      assert_in_delta ending, account.reload.trial_end_at, 1.second
+    end
+  end
+
   # The deploy window. `deploy.rb` migrates before it restarts, so for a
   # moment the old release is still serving — and its schema cache predates
   # these columns, so its INSERT does not name them. The column defaults are


### PR DESCRIPTION
The API half of the last B8 item, the backend admin. The user endpoints
already span every account; these do the same for the accounts themselves:

- `GET /backend/accounts` — the list the backend shows, paginated newest
  first, each with its plan, its two feature flags and how many people are on
  it.
- `POST /backend/accounts` — creates the account together with its first
  user, because an account is invalid without one. The admin never picks a
  password: a random one is set and the user is mailed a confirmation to
  choose their own, and `created_via_admin` makes that mail say so — the same
  flow the server-rendered form has.
- `GET /backend/accounts/:id` — new. The server-rendered screens never had a
  show action (the form read the record it was already rendering), but a
  client has to ask for it.
- `PATCH` / `DELETE` — the plan, the two feature flags and the name; and the
  deletion that takes everything on the account with it.

Admin-only through the namespace's own guard, which answers 403 rather than
redirecting.

Next PR ports the four screens (dashboard, users list + form, accounts list +
form) and deletes the ERB.

Verified: 472 ruby runs, rubocop clean, schema and client regenerated. 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added admin API support for listing, viewing, creating, updating, and deleting accounts.
  - Account creation can include the initial user and supports subscription and feature settings.
  - Added pagination for account listings and detailed account information in responses.
  - Restricted account administration to authorized administrators.
- **Documentation**
  - Added OpenAPI documentation for account endpoints, request fields, responses, and validation behavior.
- **Tests**
  - Added coverage for account management, authorization, validation errors, and unknown accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->