### PR TITLE
feat(spa): mount the SPA at the root and let it own the path space

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -7,10 +7,9 @@ class BaseController < ApplicationController
   def index
     @active_nav = "home"
     if user_signed_in?
-      # Not a permanent redirect: which of the three this is depends on the
-      # session, and a browser that cached it would never see the welcome
-      # page again.
-      redirect_to spa_path
+      # The SPA's dashboard is the root path, so this renders the shell rather
+      # than sending the browser somewhere else for it.
+      render template: "spa/index", layout: "spa"
     elsif current_account.present?
       redirect_to new_user_session_path
     else

--- a/app/frontend/pages/NotFoundPage.vue
+++ b/app/frontend/pages/NotFoundPage.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router"
+import { useI18n } from "vue-i18n"
+import UiButton from "@/components/ui/UiButton.vue"
+
+// `errors/not_found.html.erb` for the paths the SPA owns, which is all of
+// them that are not the API or a PDF.
+const { t } = useI18n()
+</script>
+
+<template>
+  <div class="py-10 text-center" data-test="not-found">
+    <h1>{{ t("notFound.title") }}</h1>
+    <p class="mt-2 text-muted">{{ t("notFound.body") }}</p>
+
+    <RouterLink v-slot="{ href, navigate }" :to="{ name: 'dashboard' }" custom>
+      <UiButton as="a" variant="primary" class="mt-5" :href="href" @click="navigate">
+        {{ t("notFound.home") }}
+      </UiButton>
+    </RouterLink>
+  </div>
+</template>

--- a/app/frontend/plugins/router.ts
+++ b/app/frontend/plugins/router.ts
@@ -2,9 +2,10 @@ import { createRouter, createWebHistory } from "vue-router";
 import type { RouteRecordRaw } from "vue-router";
 import { useCurrentUserStore } from "@/stores/currentUser";
 
-// Rails mounts the shell under /app (config/routes.rb), so the history base
-// has to match or every push would leave the SPA's own mount point.
-export const SPA_BASE = "/app";
+// The SPA is the app: Rails hands it every page load it does not claim for
+// the API, an export or the admin (config/routes.rb), so it owns the whole
+// path space and needs no prefix of its own.
+export const SPA_BASE = "/";
 
 const routes: RouteRecordRaw[] = [
   {
@@ -176,6 +177,13 @@ const routes: RouteRecordRaw[] = [
     name: "invoice-edit",
     component: () => import("@/pages/invoices/InvoiceForm.vue"),
     meta: { requiresAuth: true },
+  },
+  // Rails hands every unclaimed page load to the shell, so a typo arrives
+  // here rather than at a server-rendered 404.
+  {
+    path: "/:path(.*)",
+    name: "not-found",
+    component: () => import("@/pages/NotFoundPage.vue"),
   },
 ];
 

--- a/app/frontend/translations/de.ts
+++ b/app/frontend/translations/de.ts
@@ -1,5 +1,10 @@
 export default {
   brand: "Reckoning",
+  notFound: {
+    title: "Seite nicht vorhanden",
+    body: "Diese Seite konnte nicht gefunden werden.",
+    home: "Zum Dashboard",
+  },
   nav: {
     brand: "Reckoning",
     home: "Dashboard",

--- a/app/frontend/translations/en.ts
+++ b/app/frontend/translations/en.ts
@@ -1,5 +1,10 @@
 export default {
   brand: "Reckoning",
+  notFound: {
+    title: "No such page",
+    body: "This page could not be found.",
+    home: "To the dashboard",
+  },
   nav: {
     brand: "Reckoning",
     home: "Dashboard",

--- a/config/initializers/core_extensions/devise/json_failure_app.rb
+++ b/config/initializers/core_extensions/devise/json_failure_app.rb
@@ -43,5 +43,5 @@ class JSONFailureApp < Devise::FailureApp
     flash.discard(:alert)
   end
 
-  SPA_LOGIN_PATH = "/app/login"
+  SPA_LOGIN_PATH = "/login"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,28 +33,26 @@ Rails.application.routes.draw do
 
   mount ActionCable.server => "/cable"
 
-  # The SPA owns confirmation, unlock and password reset since phase B2.
-  # These paths stay rather than moving into the mail templates, because a
-  # link Devise sent last month is already sitting in someone's inbox and has
-  # to keep working — including for a locked account, which has no other way
-  # back in. The token travels in the query string, so it comes along.
+  # A handful of paths the SPA does not name the same way it is reached by:
+  # Devise's own URLs, which sit in mails already sent, and the two the user
+  # menu on the server-rendered layout links. Redirected rather than served,
+  # so the address bar ends up on the path the SPA knows.
   #
-  # Every path below is built through this, because `redirect("/app/…")`
-  # drops the query string: a bookmarked filtered list, or a link that
-  # preselects a project for a new invoice, would arrive bare.
-  spa_screen = ->(pattern) do
+  # Built through this rather than through `redirect("…")`, which drops the
+  # query string — and the query string is where the tokens are.
+  legacy_screen = ->(pattern) do
     redirect do |params, request|
       path = pattern % params.to_h.symbolize_keys
       [path, request.query_string.presence].compact.join("?")
     end
   end
 
-  get "/users/confirmation", to: spa_screen.call("/app/confirmation")
-  get "/users/confirmation/new", to: spa_screen.call("/app/confirmation")
-  get "/users/unlock", to: spa_screen.call("/app/unlock")
-  get "/users/unlock/new", to: spa_screen.call("/app/unlock")
-  get "/users/password/new", to: spa_screen.call("/app/password/new")
-  get "/users/password/edit", to: spa_screen.call("/app/password/edit")
+  get "/users/confirmation", to: legacy_screen.call("/confirmation")
+  get "/users/confirmation/new", to: legacy_screen.call("/confirmation")
+  get "/users/unlock", to: legacy_screen.call("/unlock")
+  get "/users/unlock/new", to: legacy_screen.call("/unlock")
+  get "/users/password/new", to: legacy_screen.call("/password/new")
+  get "/users/password/edit", to: legacy_screen.call("/password/edit")
 
   devise_for :users,
     skip: %i[sessions registrations],
@@ -65,36 +63,36 @@ Rails.application.routes.draw do
     post "signup" => "accounts#create", :as => :registration
     # The SPA owns the profile; saving goes through /api/v1. The path stays
     # because Devise's mails and the server-rendered screens link it.
-    get "settings" => spa_screen.call("/app/settings"), :as => :edit_user_registration
+    get "settings" => "spa#index", :as => :edit_user_registration
     # The SPA renders the login. The name stays so the handful of
     # `new_user_session_path` callers keep working, and a bookmark on /signin
     # still lands somewhere sensible.
-    get "signin" => spa_screen.call("/app/login"), :as => :new_user_session
+    get "signin" => legacy_screen.call("/login"), :as => :new_user_session
     delete "signout" => "sessions#destroy", :as => :destroy_user_session
   end
 
   # Two-factor is the SPA's: enrolling, the backup codes and turning it off
   # all go through /api/v1. The path stays because it was linked from the
   # profile and may sit in a bookmark.
-  get "me/otp", to: spa_screen.call("/app/settings/two-factor"), as: :otp_me
+  get "me/otp", to: legacy_screen.call("/settings/two-factor"), as: :otp_me
 
   # The SPA owns the account settings; saving goes through /api/v1. The path
   # stays because the user menu on the server-rendered screens links it.
-  get "account/edit", to: spa_screen.call("/app/account"), as: :edit_account
+  get "account/edit", to: legacy_screen.call("/account"), as: :edit_account
 
-  get "password/edit", to: spa_screen.call("/app/settings/password"), as: :edit_password
+  get "password/edit", to: legacy_screen.call("/settings/password"), as: :edit_password
 
   # The SPA owns the invoice list (phase B6). The name stays: the main
   # navigation links `invoices_path`, and so do the redirects after charging
   # or paying an invoice. The query travels with it, so a filtered, sorted
   # link keeps working.
-  get "invoices", to: spa_screen.call("/app/invoices"), as: :invoices
+  get "invoices", to: "spa#index", as: :invoices
 
   # The SPA owns the form too (phase B6). Declared before the resource so
   # `/invoices/new` reaches the SPA rather than the ERB screen, and named to
   # keep `new_invoice_path` — the dashboard and the project page link it.
-  get "invoices/new", to: spa_screen.call("/app/invoices/new"), as: :new_invoice
-  get "invoices/:id/edit", to: spa_screen.call("/app/invoices/%{id}/edit"), as: :edit_invoice
+  get "invoices/new", to: "spa#index", as: :new_invoice
+  get "invoices/:id/edit", to: "spa#index", as: :edit_invoice
 
   # What is left of the server-rendered invoice: the PDFs, which the plan keeps
   # server-rendered on purpose. Charging, paying, mailing, creating, updating
@@ -110,16 +108,16 @@ Rails.application.routes.draw do
   # longer carries `update` and `destroy` to provide `invoice_path` — the
   # dashboard and project panels link it. Declared after the resource so its
   # `:id` cannot swallow the member routes above.
-  get "invoices/:id", to: spa_screen.call("/app/invoices/%{id}"), as: :invoice
+  get "invoices/:id", to: "spa#index", as: :invoice
 
   # The SPA owns the offer screens (phase B7). The list keeps its query — the
   # main navigation links `offers_path` — and the name comes back here now
   # that the resource no longer carries `create` to provide it.
-  get "offers", to: spa_screen.call("/app/offers"), as: :offers
+  get "offers", to: "spa#index", as: :offers
 
   # `?project_id=` survives: the project page links a new offer for itself.
-  get "offers/new", to: spa_screen.call("/app/offers/new"), as: :new_offer
-  get "offers/:id/edit", to: spa_screen.call("/app/offers/%{id}/edit"), as: :edit_offer
+  get "offers/new", to: "spa#index", as: :new_offer
+  get "offers/:id/edit", to: "spa#index", as: :edit_offer
 
   # What is left of the server-rendered offer: the PDF, which the plan keeps
   # server-rendered on purpose. Creating, updating, deleting and the state
@@ -132,11 +130,11 @@ Rails.application.routes.draw do
 
   # Named because the dashboard's offer panel links it. Declared after the
   # resource so its `:id` cannot swallow the member routes above.
-  get "offers/:id", to: spa_screen.call("/app/offers/%{id}"), as: :offer
+  get "offers/:id", to: "spa#index", as: :offer
 
   # The SPA owns the timesheet (phase B4). The name stays: the main
   # navigation links `timesheet_path`.
-  get "timesheet", to: spa_screen.call("/app/timesheet"), as: :timesheet
+  get "timesheet", to: "spa#index", as: :timesheet
 
   resource :template, only: [] do
     template "blank"
@@ -149,15 +147,15 @@ Rails.application.routes.draw do
   # The SPA owns the customer screens (phase B3). The name stays because the
   # project list still links here, and a bookmark on the old path should land
   # on the new screen rather than a 404.
-  get "customers/:id/edit", to: spa_screen.call("/app/customers/%{id}/edit"), as: :edit_customer
+  get "customers/:id/edit", to: "spa#index", as: :edit_customer
 
   # The SPA owns every project screen. The names are kept, since the
   # navigation links `projects_path` and the panels around the app link the
   # detail and the form.
-  get "projects", to: spa_screen.call("/app/projects"), as: :projects
-  get "projects/new", to: spa_screen.call("/app/projects/new"), as: :new_project
-  get "projects/:id/edit", to: spa_screen.call("/app/projects/%{id}/edit"), as: :edit_project
-  get "projects/:id", to: spa_screen.call("/app/projects/%{id}"), as: :project
+  get "projects", to: "spa#index", as: :projects
+  get "projects/new", to: "spa#index", as: :new_project
+  get "projects/:id/edit", to: "spa#index", as: :edit_project
+  get "projects/:id", to: "spa#index", as: :project
 
   resources :projects, only: [] do
     # Untouched: these serve the legacy invoice screen, not the project
@@ -180,18 +178,12 @@ Rails.application.routes.draw do
   get "expenses", to: "expenses#index", as: :expenses_export,
     constraints: ->(request) { request.format.csv? || request.format.pdf? }
 
-  get "expenses", to: spa_screen.call("/app/expenses"), as: :expenses
-  get "expenses/new", to: spa_screen.call("/app/expenses/new"), as: :new_expense
-  get "expenses/:id/edit", to: spa_screen.call("/app/expenses/%{id}/edit"), as: :edit_expense
+  get "expenses", to: "spa#index", as: :expenses
+  get "expenses/new", to: "spa#index", as: :new_expense
+  get "expenses/:id/edit", to: "spa#index", as: :edit_expense
   resources :expense_imports, only: %i[new create] do
     post :preview, on: :collection
   end
-
-  # Vue SPA shell. Scoped to /app so vue-router owns everything beneath it and
-  # a reload of a client-side path still finds the shell. Deliberately not a
-  # global catch-all — the ERB screens keep their routes until Phase C.
-  get "app", to: "spa#index", as: :spa
-  get "app/*path", to: "spa#index"
 
   get "impressum" => "base#impressum"
   get "privacy" => "base#privacy"
@@ -202,4 +194,16 @@ Rails.application.routes.draw do
   match "500" => "errors#server_error", :via => :all
 
   root to: "base#index"
+
+  # The SPA owns the rest of the path space: it is the app now, so a path
+  # nothing above claims is one of its screens — or one of its screens'
+  # sub-paths, which it alone knows. Declared last so every route above wins,
+  # and narrowed to page loads: a missing asset or a stray `.json` has to stay
+  # a 404 rather than come back as a shell.
+  #
+  # `rails/` covers ActiveStorage's blob and representation URLs, which the
+  # framework draws after this file.
+  get "*path", to: "spa#index", constraints: lambda { |request|
+    request.format.html? && !request.path.start_with?("/rails/")
+  }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,15 +195,25 @@ Rails.application.routes.draw do
 
   root to: "base#index"
 
-  # The SPA owns the rest of the path space: it is the app now, so a path
-  # nothing above claims is one of its screens — or one of its screens'
-  # sub-paths, which it alone knows. Declared last so every route above wins,
-  # and narrowed to page loads: a missing asset or a stray `.json` has to stay
-  # a 404 rather than come back as a shell.
+  # The path space the server keeps, whether or not a route above claims the
+  # exact path: a typo under any of these is a 404, not a screen. `rails/` is
+  # ActiveStorage's, which the framework draws after this file.
+  server_owned_paths = %w[/api/ /api-docs /backend/ /cable /rails/ /up]
+
+  # The SPA owns the rest: it is the app now, so a path nothing above claims
+  # is one of its screens — or one of its screens' sub-paths, which it alone
+  # knows. Declared last, so every route above wins.
   #
-  # `rails/` covers ActiveStorage's blob and representation URLs, which the
-  # framework draws after this file.
+  # A page load is one that asks for HTML or asks for nothing in particular:
+  # `*/*` is what a plain `curl` and any `fetch` without an Accept header
+  # send, and answering those with a 404 would leave a route that only works
+  # in a browser. Anything naming a file stays a 404, so a missing asset
+  # cannot come back as a shell.
   get "*path", to: "spa#index", constraints: lambda { |request|
-    request.format.html? && !request.path.start_with?("/rails/")
+    format = request.format
+
+    (format.html? || format.to_s == "*/*") &&
+      File.extname(request.path).empty? &&
+      server_owned_paths.none? { |prefix| request.path.start_with?(prefix) }
   }
 end

--- a/test/controllers/customers_controller_test.rb
+++ b/test/controllers/customers_controller_test.rb
@@ -2,27 +2,29 @@
 
 require "test_helper"
 
-# The customer screens are the SPA's since phase B3. What is left on the Rails
-# side is the handover: the old path still resolves, so the link on the
-# project list and any bookmark land on the new screen.
+# The customer screens are the SPA's since phase B3, and the SPA is mounted at
+# the root — so the path the project list links is served by the shell rather
+# than handed anywhere.
 class CustomersControllerTest < ActionDispatch::IntegrationTest
   let(:data) { users :data }
   let(:customer) { customers :starfleet }
 
-  it "sends the edit path to the spa" do
+  it "serves the edit path from the shell" do
     sign_in data
 
     get "/customers/#{customer.id}/edit"
 
-    assert_redirected_to "/app/customers/#{customer.id}/edit"
+    assert_response :success
+    assert_select "div#spa"
   end
 
   # No sign-in check of its own: the SPA route guard asks the API, and the
-  # redirect target is not worth protecting — it renders the shell either way.
-  it "sends a signed-out visitor there too" do
+  # shell is not worth protecting — it renders either way.
+  it "serves a signed-out visitor too" do
     get "/customers/#{customer.id}/edit"
 
-    assert_redirected_to "/app/customers/#{customer.id}/edit"
+    assert_response :success
+    assert_select "div#spa"
   end
 
   # The SPA writes through the API, so the route the ERB form posted to is

--- a/test/controllers/expenses_controller_test.rb
+++ b/test/controllers/expenses_controller_test.rb
@@ -32,20 +32,24 @@ class ExpensesControllerTest < ActionDispatch::IntegrationTest
 
     # The query travels with it, so a bookmark on a filtered list opens the
     # same one.
-    it "forwards the list, the form and an edit to the spa" do
+    it "serves the list, the form and an edit from the shell" do
       expense = valid_expense
 
       get "/expenses"
-      assert_redirected_to "/app/expenses"
+      assert_response :success
+      assert_select "div#spa"
 
       get "/expenses?year=2025&type=licenses"
-      assert_redirected_to "/app/expenses?year=2025&type=licenses"
+      assert_response :success
+      assert_select "div#spa"
 
       get "/expenses/new?type=licenses"
-      assert_redirected_to "/app/expenses/new?type=licenses"
+      assert_response :success
+      assert_select "div#spa"
 
       get "/expenses/#{expense.id}/edit?year=2025"
-      assert_redirected_to "/app/expenses/#{expense.id}/edit?year=2025"
+      assert_response :success
+      assert_select "div#spa"
     end
 
     # Nothing asked for the csv, which is how a 500 sat in it unnoticed.

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -10,38 +10,43 @@ class InvoicesControllerTest < ActionDispatch::IntegrationTest
   let(:invoice) { invoices :january }
 
   describe "the paths that moved" do
-    it "sends the list to the spa" do
+    it "serves the list from the shell" do
       get "/invoices"
 
-      assert_redirected_to "/app/invoices"
+      assert_response :success
+      assert_select "div#spa"
     end
 
     # A filtered, sorted link has to survive the handover, or every bookmark
     # and every redirect after an action lands on an unfiltered page.
-    it "carries the query into the spa" do
+    it "serves a filtered list from the shell" do
       get "/invoices?state=paid&sort=value&direction=asc"
 
-      assert_redirected_to "/app/invoices?state=paid&sort=value&direction=asc"
+      assert_response :success
+      assert_select "div#spa"
     end
 
-    it "sends the detail page to the spa" do
+    it "serves the detail page from the shell" do
       get "/invoices/#{invoice.id}"
 
-      assert_redirected_to "/app/invoices/#{invoice.id}"
+      assert_response :success
+      assert_select "div#spa"
     end
 
     # Declared before the resource's member routes for this reason: behind
     # them, `:id` matches "new" and the form is unreachable.
-    it "sends the new form to the spa, project and all" do
+    it "serves the new form from the shell, project and all" do
       get "/invoices/new?project_id=#{projects(:narendra3).id}"
 
-      assert_redirected_to "/app/invoices/new?project_id=#{projects(:narendra3).id}"
+      assert_response :success
+      assert_select "div#spa"
     end
 
-    it "sends the edit form to the spa" do
+    it "serves the edit form from the shell" do
       get "/invoices/#{invoice.id}/edit"
 
-      assert_redirected_to "/app/invoices/#{invoice.id}/edit"
+      assert_response :success
+      assert_select "div#spa"
     end
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -11,29 +11,33 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   describe "the paths that moved" do
     before { sign_in will }
 
-    it "sends the list to the spa" do
+    it "serves the list from the shell" do
       get "/projects"
 
-      assert_redirected_to "/app/projects"
+      assert_response :success
+      assert_select "div#spa"
     end
 
-    it "sends the new form to the spa" do
+    it "serves the new form from the shell" do
       get "/projects/new"
 
-      assert_redirected_to "/app/projects/new"
+      assert_response :success
+      assert_select "div#spa"
     end
 
-    it "sends the edit form to the spa" do
+    it "serves the edit form from the shell" do
       get "/projects/#{project.id}/edit"
 
-      assert_redirected_to "/app/projects/#{project.id}/edit"
+      assert_response :success
+      assert_select "div#spa"
     end
 
     # The panels around the app link a project, and so does the dashboard.
-    it "sends a project to the spa" do
+    it "serves a project from the shell" do
       get "/projects/#{project.id}"
 
-      assert_redirected_to "/app/projects/#{project.id}"
+      assert_response :success
+      assert_select "div#spa"
     end
 
     # The SPA writes through the API, so the routes the ERB forms posted to

--- a/test/controllers/spa_controller_test.rb
+++ b/test/controllers/spa_controller_test.rb
@@ -8,7 +8,7 @@ class SpaControllerTest < ActionDispatch::IntegrationTest
   # The SPA renders its own login against /api/v1, so the shell has to reach an
   # anonymous visitor instead of being bounced to the ERB session screen.
   it "serves the shell to an anonymous visitor" do
-    get "/app"
+    get "/customers"
 
     assert_response :success
     assert_select "div#spa"
@@ -17,16 +17,17 @@ class SpaControllerTest < ActionDispatch::IntegrationTest
   it "serves the shell to a signed-in user" do
     sign_in data
 
-    get "/app"
+    get "/customers"
 
     assert_response :success
     assert_select "div#spa"
   end
 
-  # vue-router owns the paths beneath /app, so a reload of a client-side route
-  # has to find the shell rather than a 404.
-  it "serves the shell for a client-side path" do
-    get "/app/customers"
+  # vue-router owns the whole path space, so a reload of a client-side route
+  # has to find the shell rather than a 404 — including one no Rails route
+  # names, which is what the catch-all is for.
+  it "serves the shell for a client-side path nothing names" do
+    get "/settings/two-factor"
 
     assert_response :success
     assert_select "div#spa"
@@ -38,7 +39,7 @@ class SpaControllerTest < ActionDispatch::IntegrationTest
     original = ActionController::Base.allow_forgery_protection
     ActionController::Base.allow_forgery_protection = true
 
-    get "/app"
+    get "/customers"
 
     assert_select "meta[name=csrf-token]"
   ensure
@@ -49,7 +50,7 @@ class SpaControllerTest < ActionDispatch::IntegrationTest
   # Drive head merge keeps Bootstrap's unlayered CSS around, and that beats
   # Tailwind's `@layer` utilities — the SPA then renders unstyled.
   it "makes the shell's assets a full reload for turbo drive" do
-    get "/app"
+    get "/customers"
 
     assert_select "link[data-turbo-track=?]", "reload"
     assert_select "script[data-turbo-track=?]", "reload"
@@ -57,7 +58,7 @@ class SpaControllerTest < ActionDispatch::IntegrationTest
 
   # The shell must not drag in Bootstrap or the Sprockets bundle.
   it "does not load the legacy asset pipeline" do
-    get "/app"
+    get "/customers"
 
     assert_select "script[src*=?]", "application", count: 0
     assert_select "link[href*=?]", "application.css", count: 0

--- a/test/e2e/AccountSettings.spec.ts
+++ b/test/e2e/AccountSettings.spec.ts
@@ -13,7 +13,7 @@ test.describe("Account settings", () => {
     // real one carries.
     await appEval(`Account.find_by(name: "Enterprise").update_columns(plan: "free")`)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -21,7 +21,7 @@ test.describe("Account settings", () => {
   })
 
   test("saves the account's name on its own", async ({ page }) => {
-    await page.goto("/app/account")
+    await page.goto("/account")
 
     await expect(page.getByTestId("name")).toHaveValue("Enterprise")
 
@@ -33,7 +33,7 @@ test.describe("Account settings", () => {
 
   // The section is the hash, so a link into one of them keeps working.
   test("opens the section the url names and switches by the side nav", async ({ page }) => {
-    await page.goto("/app/account#banking")
+    await page.goto("/account#banking")
 
     await expect(page.getByTestId("section-banking")).toBeVisible()
 
@@ -47,7 +47,7 @@ test.describe("Account settings", () => {
   // Both office fields are what the deductible share is worked out from, and
   // a home-office expense deducts nothing until they are there.
   test("saves the office space the deduction is worked out from", async ({ page }) => {
-    await page.goto("/app/account#address")
+    await page.goto("/account#address")
 
     await page.getByTestId("office-space").fill("100")
     await page.getByTestId("deductible-office-space").fill("25")
@@ -57,7 +57,7 @@ test.describe("Account settings", () => {
   })
 
   test("saves the signature the invoice mails carry", async ({ page }) => {
-    await page.goto("/app/account#mailing")
+    await page.goto("/account#mailing")
 
     await page.getByTestId("signature").fill("Live long and prosper")
     await page.getByTestId("submit-mailing").click()
@@ -68,17 +68,17 @@ test.describe("Account settings", () => {
   test("forwards the old rails path to the spa", async ({ page }) => {
     await page.goto("/account/edit")
 
-    await expect(page).toHaveURL(/\/app\/account$/)
+    await expect(page).toHaveURL(/\/account$/)
     await expect(page.getByTestId("section-basic")).toBeVisible()
   })
 
   test("is reachable from the user menu", async ({ page }) => {
-    await page.goto("/app/")
+    await page.goto("/")
 
     await page.getByTestId("user-menu").click()
     await page.getByTestId("nav-account").click()
 
-    await expect(page).toHaveURL(/\/app\/account$/)
+    await expect(page).toHaveURL(/\/account$/)
     await expect(page.getByTestId("section-basic")).toBeVisible()
   })
 })

--- a/test/e2e/ConfirmationUnlock.spec.ts
+++ b/test/e2e/ConfirmationUnlock.spec.ts
@@ -24,7 +24,7 @@ test.describe("Confirmation and unlock", () => {
       user.confirmation_token
     `)) as string
 
-    await page.goto(`/app/confirmation?confirmation_token=${token}`)
+    await page.goto(`/confirmation?confirmation_token=${token}`)
 
     await expect(page.getByTestId("confirmation-message")).toBeVisible()
 
@@ -33,7 +33,7 @@ test.describe("Confirmation and unlock", () => {
   })
 
   test("rejects a confirmation token that was never issued", async ({ page }) => {
-    await page.goto("/app/confirmation?confirmation_token=not-a-real-token")
+    await page.goto("/confirmation?confirmation_token=not-a-real-token")
 
     await expect(page.getByTestId("confirmation-failed")).toBeVisible()
     // Falls back to the resend form rather than dead-ending.
@@ -47,7 +47,7 @@ test.describe("Confirmation and unlock", () => {
       user.send_unlock_instructions
     `)) as string
 
-    await page.goto(`/app/unlock?unlock_token=${token}`)
+    await page.goto(`/unlock?unlock_token=${token}`)
 
     await expect(page.getByTestId("unlock-message")).toBeVisible()
 
@@ -67,7 +67,7 @@ test.describe("Confirmation and unlock", () => {
 
     await page.goto(`/users/unlock?unlock_token=${token}`)
 
-    await expect(page).toHaveURL(new RegExp(`/app/unlock\\?unlock_token=${token}$`))
+    await expect(page).toHaveURL(new RegExp(`/unlock\\?unlock_token=${token}$`))
     await expect(page.getByTestId("unlock-message")).toBeVisible()
 
     const locked = await appEval(`User.find_by(email: "will@star.fleet").access_locked?`)
@@ -75,7 +75,7 @@ test.describe("Confirmation and unlock", () => {
   })
 
   test("offers a fresh unlock email when the link has expired", async ({ page }) => {
-    await page.goto("/app/unlock?unlock_token=stale")
+    await page.goto("/unlock?unlock_token=stale")
 
     await expect(page.getByTestId("unlock-failed")).toBeVisible()
 

--- a/test/e2e/Customers.spec.ts
+++ b/test/e2e/Customers.spec.ts
@@ -11,7 +11,7 @@ test.describe("Customers", () => {
       Customer.create!(account: account, name: "Starfleet", contact_information: {"email" => "ops@star.fleet"})
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -19,7 +19,7 @@ test.describe("Customers", () => {
   })
 
   test("edits a customer from the list", async ({ page }) => {
-    await page.goto("/app/customers")
+    await page.goto("/customers")
 
     await page.getByText("Starfleet").click()
 
@@ -38,7 +38,7 @@ test.describe("Customers", () => {
   test("keeps the three tabs the ERB form had", async ({ page }) => {
     const id = (await appEval(`Customer.find_by(name: "Starfleet").id`)) as string
 
-    await page.goto(`/app/customers/${id}/edit`)
+    await page.goto(`/customers/${id}/edit`)
 
     await expect(page.getByTestId("name")).toBeVisible()
 
@@ -52,7 +52,7 @@ test.describe("Customers", () => {
   test("refuses to save without a name", async ({ page }) => {
     const id = (await appEval(`Customer.find_by(name: "Starfleet").id`)) as string
 
-    await page.goto(`/app/customers/${id}/edit`)
+    await page.goto(`/customers/${id}/edit`)
     await page.getByTestId("name").fill("")
     await page.getByTestId("submit").click()
 
@@ -61,12 +61,12 @@ test.describe("Customers", () => {
   })
 
   // The project list still links to the old path, and so do bookmarks.
-  test("forwards the old rails path to the spa", async ({ page }) => {
+  test("answers a page load on the edit path", async ({ page }) => {
     const id = (await appEval(`Customer.find_by(name: "Starfleet").id`)) as string
 
     await page.goto(`/customers/${id}/edit`)
 
-    await expect(page).toHaveURL(new RegExp(`/app/customers/${id}/edit$`))
+    await expect(page).toHaveURL(new RegExp(`/customers/${id}/edit$`))
     await expect(page.getByTestId("customer-title")).toHaveText("Starfleet")
   })
 })

--- a/test/e2e/Dashboard.spec.ts
+++ b/test/e2e/Dashboard.spec.ts
@@ -17,7 +17,7 @@ test.describe("Dashboard", () => {
       paid.update_columns(value: 250, workflow_state: "paid", pay_date: Date.current)
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -124,8 +124,8 @@ test.describe("Dashboard", () => {
     await expect(page.getByTestId("trial-banner")).toHaveCount(0)
   })
 
-  test("forwards the old rails path to the spa", async ({ page }) => {
-    await page.goto("/app/")
+  test("answers a page load on the root path", async ({ page }) => {
+    await page.goto("/")
 
     await expect(page.getByTestId("dashboard-title")).toBeVisible()
   })

--- a/test/e2e/Expenses.spec.ts
+++ b/test/e2e/Expenses.spec.ts
@@ -24,7 +24,7 @@ test.describe("Expenses", () => {
       )
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -32,7 +32,7 @@ test.describe("Expenses", () => {
   })
 
   test("lists the expenses with what they add up to", async ({ page }) => {
-    await page.goto("/app/expenses")
+    await page.goto("/expenses")
 
     const list = page.getByTestId("expenses")
     await expect(list).toContainText("Tricorder")
@@ -46,7 +46,7 @@ test.describe("Expenses", () => {
   // The icon at the end of the row: a business expense files no receipt, a
   // low-value asset does.
   test("says which row is missing its receipt", async ({ page }) => {
-    await page.goto("/app/expenses")
+    await page.goto("/expenses")
 
     const gwg = (await appEval(`Expense.find_by(description: "Tricorder").id`)) as string
     const office = (await appEval(`Expense.find_by(description: "Ready room").id`)) as string
@@ -56,7 +56,7 @@ test.describe("Expenses", () => {
   })
 
   test("filters by type and keeps it in the url", async ({ page }) => {
-    await page.goto("/app/expenses")
+    await page.goto("/expenses")
 
     await page.getByTestId("filter-type").click()
     await page.getByTestId("filter-type-home_office").click()
@@ -67,7 +67,7 @@ test.describe("Expenses", () => {
   })
 
   test("searches the descriptions", async ({ page }) => {
-    await page.goto("/app/expenses")
+    await page.goto("/expenses")
 
     await page.getByTestId("search").fill("Tric")
     await page.getByTestId("search-submit").click()
@@ -79,7 +79,7 @@ test.describe("Expenses", () => {
 
   // The bar the server-rendered list slid out once a row was ticked.
   test("applies a change to the rows that were picked", async ({ page }) => {
-    await page.goto("/app/expenses")
+    await page.goto("/expenses")
 
     const id = (await appEval(`Expense.find_by(description: "Tricorder").id`)) as string
 
@@ -96,7 +96,7 @@ test.describe("Expenses", () => {
   })
 
   test("deletes the rows that were picked once the confirm is accepted", async ({ page }) => {
-    await page.goto("/app/expenses")
+    await page.goto("/expenses")
 
     const id = (await appEval(`Expense.find_by(description: "Tricorder").id`)) as string
 
@@ -108,13 +108,13 @@ test.describe("Expenses", () => {
     await expect.poll(async () => appEval(`Expense.where(description: "Tricorder").count`)).toBe(0)
   })
 
-  test("forwards the old rails path to the spa, filters and all", async ({ page }) => {
+  test("answers a page load on the list, filters and all", async ({ page }) => {
     await page.goto("/expenses")
-    await expect(page).toHaveURL(/\/app\/expenses$/)
+    await expect(page).toHaveURL(/\/expenses$/)
     await expect(page.getByTestId("expenses")).toContainText("Tricorder")
 
     await page.goto("/expenses?type=home_office")
-    await expect(page).toHaveURL(/\/app\/expenses\?type=home_office$/)
+    await expect(page).toHaveURL(/\/expenses\?type=home_office$/)
     await expect(page.getByTestId("expenses")).toContainText("Ready room")
     await expect(page.getByTestId("expenses")).not.toContainText("Tricorder")
   })
@@ -122,24 +122,24 @@ test.describe("Expenses", () => {
   // The list's filters travel with its links, so saving and cancelling both
   // land back on the list that sent you to the form.
   test("edits an expense and comes back to the list it started from", async ({ page }) => {
-    await page.goto("/app/expenses?type=home_office")
+    await page.goto("/expenses?type=home_office")
 
     const id = (await appEval(`Expense.find_by(description: "Ready room").id`)) as string
 
     await page.getByTestId(`edit-${id}`).click()
 
-    await expect(page).toHaveURL(new RegExp(`/app/expenses/${id}/edit\\?type=home_office`))
+    await expect(page).toHaveURL(new RegExp(`/expenses/${id}/edit\\?type=home_office`))
     await expect(page.getByTestId("description")).toHaveValue("Ready room")
 
     await page.getByTestId("description").fill("Ready room, refitted")
     await page.getByTestId("submit").click()
 
-    await expect(page).toHaveURL(/\/app\/expenses\?type=home_office/)
+    await expect(page).toHaveURL(/\/expenses\?type=home_office/)
     await expect(page.getByTestId("expenses")).toContainText("Ready room, refitted")
   })
 
   test("creates an expense from the form", async ({ page }) => {
-    await page.goto("/app/expenses")
+    await page.goto("/expenses")
     await page.getByTestId("new-expense").click()
 
     await page.getByTestId("expense-type").selectOption("licenses")
@@ -149,7 +149,7 @@ test.describe("Expenses", () => {
     await page.getByTestId("date").fill("2026-05-04")
     await page.getByTestId("submit").click()
 
-    await expect(page).toHaveURL(/\/app\/expenses$/)
+    await expect(page).toHaveURL(/\/expenses$/)
     await expect(page.getByTestId("expenses")).toContainText("Editor licence")
     await expect.poll(async () => appEval(`Expense.where(description: "Editor licence").count`)).toBe(1)
   })
@@ -157,7 +157,7 @@ test.describe("Expenses", () => {
   // Only an AfA expense is written off, so only it asks for a class — and
   // the endpoint refuses one without it.
   test("asks for a depreciation class once the type is afa", async ({ page }) => {
-    await page.goto("/app/expenses/new")
+    await page.goto("/expenses/new")
 
     await expect(page.getByTestId("afa-type")).toHaveCount(0)
 
@@ -169,7 +169,7 @@ test.describe("Expenses", () => {
   // The interval decides which dates the form asks for, the way
   // `expense-interval#toggle` did.
   test("swaps the date for a span once it repeats", async ({ page }) => {
-    await page.goto("/app/expenses/new")
+    await page.goto("/expenses/new")
 
     await expect(page.getByTestId("date")).toBeVisible()
 
@@ -182,13 +182,13 @@ test.describe("Expenses", () => {
   test("uploads a receipt and takes it off again", async ({ page }) => {
     const id = (await appEval(`Expense.find_by(description: "Tricorder").id`)) as string
 
-    await page.goto(`/app/expenses/${id}/edit`)
+    await page.goto(`/expenses/${id}/edit`)
     await expect(page.getByTestId("receipt-missing")).toBeVisible()
 
     await page.getByTestId("receipt-file").setInputFiles("test/fixtures/files/receipt.png")
     await page.getByTestId("submit").click()
 
-    await expect(page).toHaveURL(/\/app\/expenses$/)
+    await expect(page).toHaveURL(/\/expenses$/)
     await expect.poll(async () =>
       appEval(`Expense.find_by(description: "Tricorder").receipt.attached?`),
     ).toBe(true)
@@ -197,7 +197,7 @@ test.describe("Expenses", () => {
     await expect(page.getByTestId(`receipt-${id}`)).toBeVisible()
 
     page.on("dialog", (dialog) => dialog.accept())
-    await page.goto(`/app/expenses/${id}/edit`)
+    await page.goto(`/expenses/${id}/edit`)
     await page.getByTestId("remove-receipt").click()
 
     await expect(page.getByTestId("receipt-missing")).toBeVisible()
@@ -208,10 +208,10 @@ test.describe("Expenses", () => {
   test("copies an expense into a new one", async ({ page }) => {
     const id = (await appEval(`Expense.find_by(description: "Tricorder").id`)) as string
 
-    await page.goto(`/app/expenses/${id}/edit`)
+    await page.goto(`/expenses/${id}/edit`)
     await page.getByTestId("copy").click()
 
-    await expect(page).toHaveURL(/\/app\/expenses\/new\?/)
+    await expect(page).toHaveURL(/\/expenses\/new\?/)
     await expect(page.getByTestId("description")).toHaveValue("Tricorder")
     await expect.poll(async () => appEval(`Expense.where(description: "Tricorder").count`)).toBe(1)
   })
@@ -228,12 +228,12 @@ test.describe("Expenses", () => {
       )
     `)
 
-    await page.goto(`/app/expenses/${id}/edit`)
+    await page.goto(`/expenses/${id}/edit`)
     await expect(page.getByTestId("receipt-link")).toBeVisible()
 
     await page.getByTestId("copy").click()
 
-    await expect(page).toHaveURL(/\/app\/expenses\/new\?/)
+    await expect(page).toHaveURL(/\/expenses\/new\?/)
     await expect(page.getByTestId("description")).toHaveValue("Tricorder")
     await expect(page.getByTestId("receipt-missing")).toBeVisible()
     await expect(page.getByTestId("receipt-link")).toHaveCount(0)
@@ -243,17 +243,17 @@ test.describe("Expenses", () => {
     const id = (await appEval(`Expense.find_by(description: "Tricorder").id`)) as string
 
     page.on("dialog", (dialog) => dialog.accept())
-    await page.goto(`/app/expenses/${id}/edit`)
+    await page.goto(`/expenses/${id}/edit`)
     await page.getByTestId("delete").click()
 
-    await expect(page).toHaveURL(/\/app\/expenses$/)
+    await expect(page).toHaveURL(/\/expenses$/)
     await expect.poll(async () => appEval(`Expense.where(description: "Tricorder").count`)).toBe(0)
   })
 
   // The import is still the server-rendered screen, and it returns to the
   // list when it is done — so the link tells it which filters are on.
   test("hands the filters to the import", async ({ page }) => {
-    await page.goto("/app/expenses?type=home_office")
+    await page.goto("/expenses?type=home_office")
 
     await expect(page.getByTestId("import")).toHaveAttribute(
       "href",
@@ -264,7 +264,7 @@ test.describe("Expenses", () => {
   // The list is an account feature, and the navigation only offers it where
   // the account has it.
   test("offers the navigation entry only with the feature on", async ({ page }) => {
-    await page.goto("/app/")
+    await page.goto("/")
     await expect(page.getByTestId("nav-expenses")).toBeVisible()
 
     await appEval(`Account.find_by(name: "Enterprise").update_columns(feature_expenses: false)`)

--- a/test/e2e/Home.spec.ts
+++ b/test/e2e/Home.spec.ts
@@ -6,16 +6,19 @@ test.describe("Home", () => {
     await app("clean")
   })
 
-  test("home page loads and shows the brand", async ({ page }) => {
+  test("shows the welcome page to a visitor", async ({ page }) => {
     await page.goto("/")
+
     await expect(page.locator("body")).toContainText("Reckoning")
+    // The server-rendered welcome page, not the SPA shell behind it.
+    await expect(page.locator("#spa")).toHaveCount(0)
   })
 
   // The welcome page is for visitors; anyone with a session belongs in the app.
   test("sends a signed-in visitor into the spa", async ({ page }) => {
     await appScenario("signed_out_user")
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -23,6 +26,6 @@ test.describe("Home", () => {
 
     await page.goto("/")
 
-    await expect(page).toHaveURL(/\/app\/?$/)
+    await expect(page).toHaveURL(/^https?:\/\/[^/]+\/?$/)
   })
 })

--- a/test/e2e/InvoiceDetail.spec.ts
+++ b/test/e2e/InvoiceDetail.spec.ts
@@ -17,7 +17,7 @@ test.describe("Invoice detail", () => {
       invoice.save!
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -29,7 +29,7 @@ test.describe("Invoice detail", () => {
   test("shows the invoice, its state and its downloads", async ({ page }) => {
     const id = (await appEval(`Invoice.first.id`)) as string
 
-    await page.goto(`/app/invoices/${id}`)
+    await page.goto(`/invoices/${id}`)
 
     await expect(page.getByTestId("invoice-title")).toContainText("00001")
     await expect(page.getByTestId("state")).toContainText("Entwurf")
@@ -42,10 +42,10 @@ test.describe("Invoice detail", () => {
   test("makes every action row the control across its full width", async ({ page }) => {
     const id = (await appEval(`Invoice.first.id`)) as string
 
-    await page.goto(`/app/invoices/${id}`)
+    await page.goto(`/invoices/${id}`)
 
     const edit = page.getByTestId("edit")
-    await expect(edit).toHaveAttribute("href", `/app/invoices/${id}/edit`)
+    await expect(edit).toHaveAttribute("href", `/invoices/${id}/edit`)
 
     const box = await edit.boundingBox()
     if (!box) throw new Error("the edit row has no box")
@@ -69,7 +69,7 @@ test.describe("Invoice detail", () => {
       await route.continue()
     })
 
-    await page.goto(`/app/invoices/${id}`)
+    await page.goto(`/invoices/${id}`)
 
     await expect(page.getByTestId("pdf-loading")).toBeVisible()
 
@@ -84,7 +84,7 @@ test.describe("Invoice detail", () => {
   test("renders the invoice PDF inline", async ({ page }) => {
     const id = (await appEval(`Invoice.first.id`)) as string
 
-    await page.goto(`/app/invoices/${id}`)
+    await page.goto(`/invoices/${id}`)
 
     await expect(page.locator('[data-test="pdf-pages"] canvas').first()).toBeVisible({ timeout: 60_000 })
   })
@@ -92,7 +92,7 @@ test.describe("Invoice detail", () => {
   test("charges and then pays the invoice", async ({ page }) => {
     const id = (await appEval(`Invoice.first.id`)) as string
 
-    await page.goto(`/app/invoices/${id}`)
+    await page.goto(`/invoices/${id}`)
 
     page.once("dialog", (dialog) => dialog.accept())
     await page.getByTestId("charge").click()
@@ -109,7 +109,7 @@ test.describe("Invoice detail", () => {
   test("leaves the invoice alone when the charge confirm is declined", async ({ page }) => {
     const id = (await appEval(`Invoice.first.id`)) as string
 
-    await page.goto(`/app/invoices/${id}`)
+    await page.goto(`/invoices/${id}`)
 
     page.once("dialog", (dialog) => dialog.dismiss())
     await page.getByTestId("charge").click()
@@ -129,7 +129,7 @@ test.describe("Invoice detail", () => {
         .update_columns(plan: "basic", trial_used: true, trial_end_at: 1.minute.ago)
     `)
 
-    await page.goto(`/app/invoices/${id}`)
+    await page.goto(`/invoices/${id}`)
 
     await expect(page.getByTestId("invoice-title")).toContainText("00001")
     await expect(page.getByTestId("charge")).toHaveCount(0)
@@ -137,12 +137,12 @@ test.describe("Invoice detail", () => {
     await expect(page.getByTestId("delete")).toHaveCount(0)
   })
 
-  test("forwards the old rails path to the spa", async ({ page }) => {
+  test("answers a page load on the detail path", async ({ page }) => {
     const id = (await appEval(`Invoice.first.id`)) as string
 
     await page.goto(`/invoices/${id}`)
 
-    await expect(page).toHaveURL(new RegExp(`/app/invoices/${id}$`))
+    await expect(page).toHaveURL(new RegExp(`/invoices/${id}$`))
     await expect(page.getByTestId("invoice-title")).toContainText("00001")
   })
 })

--- a/test/e2e/InvoiceForm.spec.ts
+++ b/test/e2e/InvoiceForm.spec.ts
@@ -18,7 +18,7 @@ test.describe("Invoice form", () => {
       Timer.create!(user: user, task: task, date: Date.current - 1, value: 0.5)
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -28,7 +28,7 @@ test.describe("Invoice form", () => {
   test("writes an invoice with a hand-typed position", async ({ page }) => {
     const projectId = (await appEval(`Project.first.id`)) as string
 
-    await page.goto(`/app/invoices/new?project_id=${projectId}`)
+    await page.goto(`/invoices/new?project_id=${projectId}`)
 
     await page.getByTestId("date").fill("2026-03-01")
     await page.getByTestId("position-description-0").fill("Beratung")
@@ -52,7 +52,7 @@ test.describe("Invoice form", () => {
   test("generates a position from uninvoiced time", async ({ page }) => {
     const projectId = (await appEval(`Project.first.id`)) as string
 
-    await page.goto(`/app/invoices/new?project_id=${projectId}`)
+    await page.goto(`/invoices/new?project_id=${projectId}`)
     await page.getByTestId("date").fill("2026-03-01")
 
     await page.getByTestId("generate-positions").click()
@@ -86,7 +86,7 @@ test.describe("Invoice form", () => {
       position.timers << Timer.order(:date).last
     `)
 
-    await page.goto(`/app/invoices/new?project_id=${projectId}`)
+    await page.goto(`/invoices/new?project_id=${projectId}`)
     await page.getByTestId("generate-positions").click()
 
     const taskId = (await appEval(`Task.first.id`)) as string
@@ -105,7 +105,7 @@ test.describe("Invoice form", () => {
     `)
     const id = (await appEval(`Invoice.first.id`)) as string
 
-    await page.goto(`/app/invoices/${id}/edit`)
+    await page.goto(`/invoices/${id}/edit`)
 
     await expect(page.getByTestId("position-description-0")).toHaveValue("Alt")
 
@@ -118,11 +118,11 @@ test.describe("Invoice form", () => {
     expect(remaining).toEqual(["Bleibt"])
   })
 
-  test("forwards the old rails paths to the spa", async ({ page }) => {
+  test("answers a page load on the form paths", async ({ page }) => {
     const id = (await appEval(`Project.first.id`)) as string
 
     await page.goto(`/invoices/new?project_id=${id}`)
-    await expect(page).toHaveURL(new RegExp(`/app/invoices/new\\?project_id=${id}$`))
+    await expect(page).toHaveURL(new RegExp(`/invoices/new\\?project_id=${id}$`))
   })
 
   // The ERB form rendered the project select for `new` and `edit` alike. Time
@@ -141,7 +141,7 @@ test.describe("Invoice form", () => {
     const id = (await appEval(`Invoice.first.id`)) as string
     const other = (await appEval(`Project.find_by(name: "Outpost 6").id`)) as string
 
-    await page.goto(`/app/invoices/${id}/edit`)
+    await page.goto(`/invoices/${id}/edit`)
 
     await expect(page.getByTestId("position-description-0")).toHaveValue("Away mission")
 

--- a/test/e2e/Invoices.spec.ts
+++ b/test/e2e/Invoices.spec.ts
@@ -19,7 +19,7 @@ test.describe("Invoices", () => {
       open_one.update_columns(value: 250, workflow_state: "created")
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -27,7 +27,7 @@ test.describe("Invoices", () => {
   })
 
   test("lists the invoices with what they add up to", async ({ page }) => {
-    await page.goto("/app/invoices")
+    await page.goto("/invoices")
 
     const table = page.getByTestId("invoices")
     await expect(table).toContainText("00001")
@@ -39,7 +39,7 @@ test.describe("Invoices", () => {
   })
 
   test("filters, and the total follows the filter", async ({ page }) => {
-    await page.goto("/app/invoices")
+    await page.goto("/invoices")
 
     await page.getByTestId("filter-state").click()
     await page.getByTestId("filter-state-paid").click()
@@ -50,7 +50,7 @@ test.describe("Invoices", () => {
   })
 
   test("sorts by a column and says which way", async ({ page }) => {
-    await page.goto("/app/invoices")
+    await page.goto("/invoices")
 
     await page.getByTestId("sort-value").click()
 
@@ -63,10 +63,10 @@ test.describe("Invoices", () => {
 
   // The navigation links `invoices_path`, and so do the redirects after
   // charging or paying an invoice.
-  test("forwards the old rails path with its query", async ({ page }) => {
+  test("answers a page load on the list, query and all", async ({ page }) => {
     await page.goto("/invoices?state=paid")
 
-    await expect(page).toHaveURL(/\/app\/invoices\?state=paid$/)
+    await expect(page).toHaveURL(/\/invoices\?state=paid$/)
     await expect(page.getByTestId("invoices")).toContainText("00001")
   })
 })

--- a/test/e2e/LoginSecurity.spec.ts
+++ b/test/e2e/LoginSecurity.spec.ts
@@ -17,7 +17,7 @@ test.describe("SPA login security", () => {
       user.save(validate: false)
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -46,7 +46,7 @@ test.describe("SPA login security", () => {
       codes.first
     `)) as string
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("otp-token").fill(code)
@@ -63,7 +63,7 @@ test.describe("SPA login security", () => {
         .update_columns(failed_attempts: User.maximum_attempts - 1)
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("definitely-not-enterprise")
     await page.getByTestId("submit").click()
@@ -79,6 +79,6 @@ test.describe("SPA login security", () => {
     await page.getByTestId("submit").click()
 
     await expect(page.getByTestId("login-failed")).toBeVisible()
-    await expect(page).toHaveURL(/\/app\/login/)
+    await expect(page).toHaveURL(/\/login/)
   })
 })

--- a/test/e2e/OfferDetail.spec.ts
+++ b/test/e2e/OfferDetail.spec.ts
@@ -17,7 +17,7 @@ test.describe("Offer detail", () => {
       offer.save!
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -29,7 +29,7 @@ test.describe("Offer detail", () => {
   test("shows the offer, its state and its download", async ({ page }) => {
     const id = (await appEval(`Offer.first.id`)) as string
 
-    await page.goto(`/app/offers/${id}`)
+    await page.goto(`/offers/${id}`)
 
     await expect(page.getByTestId("offer-title")).toContainText("00001")
     await expect(page.getByTestId("state")).toContainText("Entwurf")
@@ -39,7 +39,7 @@ test.describe("Offer detail", () => {
   test("renders the offer PDF inline", async ({ page }) => {
     const id = (await appEval(`Offer.first.id`)) as string
 
-    await page.goto(`/app/offers/${id}`)
+    await page.goto(`/offers/${id}`)
 
     await expect(page.locator('[data-test="pdf-pages"] canvas').first()).toBeVisible({ timeout: 60_000 })
   })
@@ -49,7 +49,7 @@ test.describe("Offer detail", () => {
   test("walks the offer through its state machine", async ({ page }) => {
     const id = (await appEval(`Offer.first.id`)) as string
 
-    await page.goto(`/app/offers/${id}`)
+    await page.goto(`/offers/${id}`)
 
     page.once("dialog", (dialog) => dialog.accept())
     await page.getByTestId("transition-bid").click()
@@ -70,7 +70,7 @@ test.describe("Offer detail", () => {
   test("leaves the offer alone when the confirm is declined", async ({ page }) => {
     const id = (await appEval(`Offer.first.id`)) as string
 
-    await page.goto(`/app/offers/${id}`)
+    await page.goto(`/offers/${id}`)
 
     page.once("dialog", (dialog) => dialog.dismiss())
     await page.getByTestId("transition-bid").click()
@@ -91,7 +91,7 @@ test.describe("Offer detail", () => {
       offer.decline!
     `)
 
-    await page.goto(`/app/offers/${id}`)
+    await page.goto(`/offers/${id}`)
 
     await expect(page.getByTestId("state")).toContainText("Abgelehnt")
     await expect(page.getByTestId("transition-bid")).toBeVisible()
@@ -104,7 +104,7 @@ test.describe("Offer detail", () => {
         .update_columns(plan: "basic", trial_used: true, trial_end_at: 1.minute.ago)
     `)
 
-    await page.goto(`/app/offers/${id}`)
+    await page.goto(`/offers/${id}`)
 
     await expect(page.getByTestId("offer-title")).toContainText("00001")
     await expect(page.getByTestId("transition-bid")).toHaveCount(0)
@@ -112,12 +112,12 @@ test.describe("Offer detail", () => {
     await expect(page.getByTestId("delete")).toHaveCount(0)
   })
 
-  test("forwards the old rails path to the spa", async ({ page }) => {
+  test("answers a page load on the detail path", async ({ page }) => {
     const id = (await appEval(`Offer.first.id`)) as string
 
     await page.goto(`/offers/${id}`)
 
-    await expect(page).toHaveURL(new RegExp(`/app/offers/${id}$`))
+    await expect(page).toHaveURL(new RegExp(`/offers/${id}$`))
     await expect(page.getByTestId("offer-title")).toContainText("00001")
   })
 })

--- a/test/e2e/OfferForm.spec.ts
+++ b/test/e2e/OfferForm.spec.ts
@@ -13,7 +13,7 @@ test.describe("Offer form", () => {
       customer.projects.create!(name: "Narendra 3", rate: 90)
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -23,7 +23,7 @@ test.describe("Offer form", () => {
   test("writes an offer with a hand-typed position", async ({ page }) => {
     const projectId = (await appEval(`Project.first.id`)) as string
 
-    await page.goto(`/app/offers/new?project_id=${projectId}`)
+    await page.goto(`/offers/new?project_id=${projectId}`)
 
     await page.getByTestId("date").fill("2026-08-01")
     await page.getByTestId("description").fill("Sector survey")
@@ -50,7 +50,7 @@ test.describe("Offer form", () => {
     `)
     const id = (await appEval(`Offer.first.id`)) as string
 
-    await page.goto(`/app/offers/${id}/edit`)
+    await page.goto(`/offers/${id}/edit`)
 
     await expect(page.getByTestId("position-description-0")).toHaveValue("Away mission")
 
@@ -74,7 +74,7 @@ test.describe("Offer form", () => {
     const id = (await appEval(`Offer.first.id`)) as string
     const other = (await appEval(`Project.find_by(name: "Outpost 6").id`)) as string
 
-    await page.goto(`/app/offers/${id}/edit`)
+    await page.goto(`/offers/${id}/edit`)
 
     await expect(page.getByTestId("position-description-0")).toHaveValue("Design")
 
@@ -90,17 +90,17 @@ test.describe("Offer form", () => {
   test("refuses a new offer while the account has no address", async ({ page }) => {
     await appEval(`Account.find_by(name: "Enterprise").update_columns(contact_information: {})`)
 
-    await page.goto("/app/offers/new")
+    await page.goto("/offers/new")
 
     await expect(page.getByTestId("missing-address")).toBeVisible()
   })
 
-  test("forwards the old rails paths to the spa", async ({ page }) => {
+  test("answers a page load on the form paths", async ({ page }) => {
     const projectId = (await appEval(`Project.first.id`)) as string
 
     await page.goto(`/offers/new?project_id=${projectId}`)
 
-    await expect(page).toHaveURL(new RegExp(`/app/offers/new\\?project_id=${projectId}$`))
+    await expect(page).toHaveURL(new RegExp(`/offers/new\\?project_id=${projectId}$`))
     await expect(page.getByTestId("offer-form-title")).toBeVisible()
   })
 })

--- a/test/e2e/Offers.spec.ts
+++ b/test/e2e/Offers.spec.ts
@@ -19,7 +19,7 @@ test.describe("Offers", () => {
       open_one.update_columns(value: 250, aasm_state: "bided")
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -27,7 +27,7 @@ test.describe("Offers", () => {
   })
 
   test("lists the offers with what they add up to", async ({ page }) => {
-    await page.goto("/app/offers")
+    await page.goto("/offers")
 
     const table = page.getByTestId("offers")
     await expect(table).toContainText("00001")
@@ -40,7 +40,7 @@ test.describe("Offers", () => {
   })
 
   test("filters, and the total follows the filter", async ({ page }) => {
-    await page.goto("/app/offers")
+    await page.goto("/offers")
 
     await page.getByTestId("filter-state").click()
     await page.getByTestId("filter-state-accepted").click()
@@ -51,7 +51,7 @@ test.describe("Offers", () => {
   })
 
   test("sorts by a column and says which way", async ({ page }) => {
-    await page.goto("/app/offers")
+    await page.goto("/offers")
 
     await page.getByTestId("sort-value").click()
 
@@ -64,10 +64,10 @@ test.describe("Offers", () => {
 
   // The main navigation links `offers_path`, and so do the redirects after
   // creating or updating an offer.
-  test("forwards the old rails path with its query", async ({ page }) => {
+  test("answers a page load on the list, query and all", async ({ page }) => {
     await page.goto("/offers?state=accepted")
 
-    await expect(page).toHaveURL(/\/app\/offers\?state=accepted$/)
+    await expect(page).toHaveURL(/\/offers\?state=accepted$/)
     await expect(page.getByTestId("offers")).toContainText("00001")
   })
 })

--- a/test/e2e/ProfileSettings.spec.ts
+++ b/test/e2e/ProfileSettings.spec.ts
@@ -8,7 +8,7 @@ test.describe("Profile settings", () => {
     await app("clean")
     await appScenario("signed_out_user")
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -16,7 +16,7 @@ test.describe("Profile settings", () => {
   })
 
   test("saves the name", async ({ page }) => {
-    await page.goto("/app/settings")
+    await page.goto("/settings")
 
     await expect(page.getByTestId("name")).toHaveValue("Will Riker")
 
@@ -29,7 +29,7 @@ test.describe("Profile settings", () => {
   // The address the avatar is looked up under is not necessarily the one you
   // sign in with.
   test("saves the gravatar address beside the login one", async ({ page }) => {
-    await page.goto("/app/settings#security")
+    await page.goto("/settings#security")
 
     await page.getByTestId("gravatar").fill("riker@star.fleet")
     await page.getByTestId("submit-security").click()
@@ -38,28 +38,28 @@ test.describe("Profile settings", () => {
   })
 
   test("says whether two-factor is on and leads to it", async ({ page }) => {
-    await page.goto("/app/settings#security")
+    await page.goto("/settings#security")
 
     await expect(page.getByTestId("two-factor-state")).toBeVisible()
 
     await page.getByTestId("two-factor").click()
 
-    await expect(page).toHaveURL(/\/app\/settings\/two-factor$/)
+    await expect(page).toHaveURL(/\/settings\/two-factor$/)
     await expect(page.getByTestId("two-factor-title")).toBeVisible()
   })
 
   test("changes the password and lets the new one sign in", async ({ page }) => {
-    await page.goto("/app/settings#security")
+    await page.goto("/settings#security")
     await page.getByTestId("change-password").click()
 
-    await expect(page).toHaveURL(/\/app\/settings\/password$/)
+    await expect(page).toHaveURL(/\/settings\/password$/)
 
     await page.getByTestId("current-password").fill("enterprise")
     await page.getByTestId("password").fill("warpcore9")
     await page.getByTestId("password-confirmation").fill("warpcore9")
     await page.getByTestId("submit").click()
 
-    await expect(page).toHaveURL(/\/app\/settings/)
+    await expect(page).toHaveURL(/\/settings/)
     await expect
       .poll(async () => appEval(`User.first.valid_password?("warpcore9")`))
       .toBe(true)
@@ -67,7 +67,7 @@ test.describe("Profile settings", () => {
     // The session survives a password change, and the router keeps someone
     // signed in off the login screen — so the proof needs a fresh one.
     await page.context().clearCookies()
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("warpcore9")
     await page.getByTestId("submit").click()
@@ -76,7 +76,7 @@ test.describe("Profile settings", () => {
   })
 
   test("says so when the current password was wrong", async ({ page }) => {
-    await page.goto("/app/settings/password")
+    await page.goto("/settings/password")
 
     await page.getByTestId("current-password").fill("not-the-one")
     await page.getByTestId("password").fill("warpcore9")
@@ -84,28 +84,28 @@ test.describe("Profile settings", () => {
     await page.getByTestId("submit").click()
 
     await expect(page.getByTestId("refused")).toBeVisible()
-    await expect(page).toHaveURL(/\/app\/settings\/password$/)
+    await expect(page).toHaveURL(/\/settings\/password$/)
   })
 
   // The paths the server-rendered screens and Devise's mails link.
   test("forwards the old rails paths to the spa", async ({ page }) => {
     await page.goto("/settings")
-    await expect(page).toHaveURL(/\/app\/settings$/)
+    await expect(page).toHaveURL(/\/settings$/)
 
     await page.goto("/password/edit")
-    await expect(page).toHaveURL(/\/app\/settings\/password$/)
+    await expect(page).toHaveURL(/\/settings\/password$/)
 
     await page.goto("/me/otp")
-    await expect(page).toHaveURL(/\/app\/settings\/two-factor$/)
+    await expect(page).toHaveURL(/\/settings\/two-factor$/)
   })
 
   test("is reachable from the user menu", async ({ page }) => {
-    await page.goto("/app/")
+    await page.goto("/")
 
     await page.getByTestId("user-menu").click()
     await page.getByTestId("nav-profile").click()
 
-    await expect(page).toHaveURL(/\/app\/settings$/)
+    await expect(page).toHaveURL(/\/settings$/)
     await expect(page.getByTestId("name")).toBeVisible()
   })
 })

--- a/test/e2e/ProjectDetail.spec.ts
+++ b/test/e2e/ProjectDetail.spec.ts
@@ -22,7 +22,7 @@ test.describe("Project detail", () => {
       offer.update_columns(value: 900)
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -35,7 +35,7 @@ test.describe("Project detail", () => {
 
   test("draws the budget chart and the numbers under it", async ({ page }) => {
     const id = await projectId()
-    await page.goto(`/app/projects/${id}`)
+    await page.goto(`/projects/${id}`)
 
     await expect(page.getByTestId("project-title")).toContainText("Narendra 3")
 
@@ -56,7 +56,7 @@ test.describe("Project detail", () => {
 
   test("lists the project's offers, invoices and tasks in their tabs", async ({ page }) => {
     const id = await projectId()
-    await page.goto(`/app/projects/${id}`)
+    await page.goto(`/projects/${id}`)
 
     await page.getByTestId("tab-invoices").click()
     await expect(page).toHaveURL(/#invoices$/)
@@ -74,7 +74,7 @@ test.describe("Project detail", () => {
 
   test("opens the tab the url names", async ({ page }) => {
     const id = await projectId()
-    await page.goto(`/app/projects/${id}#tasks`)
+    await page.goto(`/projects/${id}#tasks`)
 
     await expect(page.getByTestId("tasks")).toContainText("Away mission")
   })
@@ -83,28 +83,28 @@ test.describe("Project detail", () => {
   // form reads the project out of the query.
   test("starts a new invoice for the project it is showing", async ({ page }) => {
     const id = await projectId()
-    await page.goto(`/app/projects/${id}`)
+    await page.goto(`/projects/${id}`)
 
     await page.getByTestId("add-invoice").click()
 
-    await expect(page).toHaveURL(new RegExp(`/app/invoices/new\\?project_id=${id}`))
+    await expect(page).toHaveURL(new RegExp(`/invoices/new\\?project_id=${id}`))
   })
 
-  test("forwards the old rails path to the spa", async ({ page }) => {
+  test("answers a page load on the detail path", async ({ page }) => {
     const id = await projectId()
 
     await page.goto(`/projects/${id}`)
 
-    await expect(page).toHaveURL(new RegExp(`/app/projects/${id}$`))
+    await expect(page).toHaveURL(new RegExp(`/projects/${id}$`))
     await expect(page.getByTestId("project-title")).toContainText("Narendra 3")
   })
 
   test("is reachable from the project list", async ({ page }) => {
-    await page.goto("/app/projects")
+    await page.goto("/projects")
 
     await page.getByText("Narendra 3").first().click()
 
-    await expect(page).toHaveURL(/\/app\/projects\/[0-9a-f-]+$/)
+    await expect(page).toHaveURL(/\/projects\/[0-9a-f-]+$/)
     await expect(page.getByTestId("budget-panel")).toBeVisible()
   })
 })

--- a/test/e2e/Projects.spec.ts
+++ b/test/e2e/Projects.spec.ts
@@ -16,7 +16,7 @@ test.describe("Projects", () => {
       project.tasks.create!(name: "Away mission", billable: true)
     `)
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -24,7 +24,7 @@ test.describe("Projects", () => {
   })
 
   test("lists projects under their customer and edits one", async ({ page }) => {
-    await page.goto("/app/projects")
+    await page.goto("/projects")
 
     await expect(page.getByTestId("customer-name")).toContainText("Starfleet")
     await expect(page.getByText("Narendra 3")).toBeVisible()
@@ -46,7 +46,7 @@ test.describe("Projects", () => {
   test("adds a task to a project", async ({ page }) => {
     const id = (await appEval(`Project.find_by(name: "Narendra 3").id`)) as string
 
-    await page.goto(`/app/projects/${id}/edit`)
+    await page.goto(`/projects/${id}/edit`)
     await page.getByTestId("add-task").click()
     await page.getByTestId("task-name-1").fill("Shore leave")
     await page.getByTestId("submit").click()
@@ -58,7 +58,7 @@ test.describe("Projects", () => {
   })
 
   test("archives a project and finds it under the archived filter", async ({ page }) => {
-    await page.goto("/app/projects")
+    await page.goto("/projects")
 
     await page.locator('[data-test^="actions-"]').first().click()
     page.once("dialog", (dialog) => dialog.accept())
@@ -72,12 +72,12 @@ test.describe("Projects", () => {
   })
 
   // The main navigation still links `projects_path`, and so do bookmarks.
-  test("forwards the old rails paths to the spa", async ({ page }) => {
+  test("answers a page load on the project paths", async ({ page }) => {
     await page.goto("/projects")
-    await expect(page).toHaveURL(/\/app\/projects$/)
+    await expect(page).toHaveURL(/\/projects$/)
 
     await page.goto("/projects/new")
-    await expect(page).toHaveURL(/\/app\/projects\/new$/)
+    await expect(page).toHaveURL(/\/projects\/new$/)
   })
 
   // Deleting the guard with the ERB screen would have let a project be created
@@ -85,7 +85,7 @@ test.describe("Projects", () => {
   test("refuses a new project while the account has no address", async ({ page }) => {
     await appEval(`Account.find_by(name: "Enterprise").update_columns(contact_information: {})`)
 
-    await page.goto("/app/projects/new")
+    await page.goto("/projects/new")
 
     await expect(page.getByTestId("missing-address")).toBeVisible()
     await expect(page.getByTestId("name")).toHaveCount(0)

--- a/test/e2e/Spa.spec.ts
+++ b/test/e2e/Spa.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "./support/commands"
 import { app, appScenario, appEval } from "./support/on-rails"
 
-// Phase B1's exit criterion: the shell at /app does a full login → dashboard
+// Phase B1's exit criterion: the shell does a full login → dashboard
 // → logout round-trip against the real API, not a mocked one.
 test.describe("SPA shell", () => {
   test.beforeEach(async () => {
@@ -10,32 +10,30 @@ test.describe("SPA shell", () => {
   })
 
   test("signs in, reaches the dashboard and signs back out", async ({ page }) => {
-    await page.goto("/app")
-
-    // The guard asks GET /me, gets a 401 and routes to login client-side,
-    // carrying the route it turned away as a redirect query.
-    await expect(page).toHaveURL(/\/app\/login\?redirect=\/$/)
+    // Not the root path: a signed-out visitor there is a visitor, and gets
+    // the welcome page. The dashboard behind it is what signing in reaches.
+    await page.goto("/login")
 
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
 
     await expect(page.getByTestId("dashboard-greeting")).toContainText("will@star.fleet")
-    await expect(page).toHaveURL(/\/app\/?$/)
+    await expect(page).toHaveURL(/^https?:\/\/[^/]+\/?$/)
 
     // Signing out lives in the user menu, the way the server-rendered aside
     // has it.
     await page.getByTestId("user-menu").click()
     await page.getByTestId("sign-out").click()
 
-    await expect(page).toHaveURL(/\/app\/login$/)
+    await expect(page).toHaveURL(/\/login$/)
     await expect(page.getByTestId("submit")).toBeVisible()
   })
 
   // The bar the server-rendered pages get from Turbo Drive. It waits half a
   // second first, so the request has to be held up to see it at all.
   test("draws the loading bar while a request is in flight", async ({ page }) => {
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -49,7 +47,7 @@ test.describe("SPA shell", () => {
     await page.getByTestId("nav-invoices").click()
 
     await expect(page.getByTestId("loading-bar")).toBeVisible()
-    await expect(page).toHaveURL(/\/app\/invoices$/)
+    await expect(page).toHaveURL(/\/invoices$/)
 
     // And it leaves again once the answer is in.
     await expect(page.getByTestId("loading-bar")).toHaveCount(0, { timeout: 15_000 })
@@ -57,31 +55,31 @@ test.describe("SPA shell", () => {
   })
 
   test("keeps the requested path through the login redirect", async ({ page }) => {
-    await page.goto("/app/customers")
+    await page.goto("/customers")
 
-    await expect(page).toHaveURL(/\/app\/login\?redirect=\/customers$/)
+    await expect(page).toHaveURL(/\/login\?redirect=\/customers$/)
 
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
 
-    await expect(page).toHaveURL(/\/app\/customers$/)
+    await expect(page).toHaveURL(/\/customers$/)
   })
 
   test("rejects bad credentials without leaving the login page", async ({ page }) => {
-    await page.goto("/app/login")
+    await page.goto("/login")
 
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("definitely-not-enterprise")
     await page.getByTestId("submit").click()
 
     await expect(page.getByTestId("login-failed")).toBeVisible()
-    await expect(page).toHaveURL(/\/app\/login$/)
+    await expect(page).toHaveURL(/\/login$/)
   })
 
   // The elements /signin has that the B1 skeleton was missing.
   test("offers remember me, password reset and signup", async ({ page }) => {
-    await page.goto("/app/login")
+    await page.goto("/login")
 
     await expect(page.getByTestId("remember-me")).toBeVisible()
     await expect(page.getByTestId("reset-password")).toBeVisible()
@@ -90,12 +88,12 @@ test.describe("SPA shell", () => {
     await expect(page.getByTestId("sign-up")).toHaveAttribute("href", "/signup")
 
     await page.getByTestId("reset-password").click()
-    await expect(page).toHaveURL(/\/app\/password\/new$/)
+    await expect(page).toHaveURL(/\/password\/new$/)
     await expect(page.getByTestId("submit")).toBeVisible()
   })
 
   test("keeps the session across a browser restart when remember me is checked", async ({ page }) => {
-    await page.goto("/app/login")
+    await page.goto("/login")
 
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
@@ -116,16 +114,16 @@ test.describe("SPA shell", () => {
   // bounce straight back to login — only reachable on a fresh load, so
   // clicking through from the login page never caught it.
   test("opens a public route directly without bouncing to login", async ({ page }) => {
-    await page.goto("/app/password/new")
+    await page.goto("/password/new")
 
-    await expect(page).toHaveURL(/\/app\/password\/new$/)
+    await expect(page).toHaveURL(/\/password\/new$/)
     await expect(page.getByTestId("email")).toBeVisible()
   })
 
   // The root path used to serve the server-rendered dashboard, and the menu
   // had a way across to it. It hands a signed-in visitor to the SPA now.
   test("takes a signed-in visitor from the root path into the spa", async ({ page }) => {
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -133,7 +131,7 @@ test.describe("SPA shell", () => {
 
     await page.goto("/")
 
-    await expect(page).toHaveURL(/\/app\/?$/)
+    await expect(page).toHaveURL(/^https?:\/\/[^/]+\/?$/)
     await expect(page.getByTestId("dashboard-title")).toBeVisible()
   })
 
@@ -141,7 +139,7 @@ test.describe("SPA shell", () => {
   // has run out, and redirects to the root path with the reason in the flash.
   // The root path now hands that to the SPA, which has to say it out loud.
   test("carries a server-rendered refusal into the spa", async ({ page }) => {
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -164,7 +162,7 @@ test.describe("SPA shell", () => {
       form.submit()
     }, id)
 
-    await expect(page).toHaveURL(/\/app\/?$/)
+    await expect(page).toHaveURL(/^https?:\/\/[^/]+\/?$/)
     await expect(page.getByTestId("toasts")).toContainText("Testphase")
   })
 
@@ -184,7 +182,7 @@ test.describe("SPA shell", () => {
 
     await page.goto("/expense_imports/new")
 
-    await expect(page).toHaveURL(/\/app\/login\?return=%2Fexpense_imports%2Fnew$/)
+    await expect(page).toHaveURL(/\/login\?return=%2Fexpense_imports%2Fnew$/)
 
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
@@ -196,7 +194,7 @@ test.describe("SPA shell", () => {
   })
 
   test("validates the form before calling the api", async ({ page }) => {
-    await page.goto("/app/login")
+    await page.goto("/login")
 
     await page.getByTestId("email").fill("not-an-email")
     await page.getByTestId("submit").click()

--- a/test/e2e/TimersCalendar.spec.ts
+++ b/test/e2e/TimersCalendar.spec.ts
@@ -9,7 +9,7 @@ test.describe("Timers calendar", () => {
     await app("clean")
     await appScenario("timesheet_week")
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()

--- a/test/e2e/Timesheet.spec.ts
+++ b/test/e2e/Timesheet.spec.ts
@@ -11,7 +11,7 @@ test.describe("Timesheet week view", () => {
   })
 
   async function signIn(page: Page) {
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -20,7 +20,7 @@ test.describe("Timesheet week view", () => {
 
   test("renders the seeded task row with its week total", async ({page}) => {
     await signIn(page)
-    await page.goto("/app/timesheet?view=week")
+    await page.goto("/timesheet?view=week")
 
     await expect(page.getByTestId("week-grid")).toBeVisible()
 
@@ -37,19 +37,19 @@ test.describe("Timesheet week view", () => {
   // where it now actually appears.
   // The main navigation and the running-timer widget still link
   // `timesheet_path`, and a bookmark carries a date with it.
-  test("forwards the old rails path, date and all", async ({ page }) => {
+  test("answers a page load with the date in the query", async ({ page }) => {
     await signIn(page)
 
     await page.goto("/timesheet?date=2026-06-10&view=week")
 
-    await expect(page).toHaveURL(/\/app\/timesheet\?date=2026-06-10&view=week$/)
+    await expect(page).toHaveURL(/\/timesheet\?date=2026-06-10&view=week$/)
     // A week with nothing tracked in it, so the page itself is the assertion.
     await expect(page.getByText("Heute")).toBeVisible()
   })
 
   test("removes a row only after the confirm is accepted", async ({page}) => {
     await signIn(page)
-    await page.goto("/app/timesheet?view=week")
+    await page.goto("/timesheet?view=week")
 
     const row = page.getByTestId("task-row").filter({hasText: "E2E Task"})
     await expect(row).toBeVisible()
@@ -66,7 +66,7 @@ test.describe("Timesheet week view", () => {
 
   test("autosaves a cell edit and recomputes the row total", async ({page}) => {
     await signIn(page)
-    await page.goto("/app/timesheet?view=week")
+    await page.goto("/timesheet?view=week")
 
     const row = page.getByTestId("task-row").filter({hasText: "E2E Task"})
     const inputs = row.getByTestId("week-cells").locator("input")

--- a/test/e2e/TwoFactor.spec.ts
+++ b/test/e2e/TwoFactor.spec.ts
@@ -9,7 +9,7 @@ test.describe("Two-factor settings", () => {
     await app("clean")
     await appScenario("signed_out_user")
 
-    await page.goto("/app/login")
+    await page.goto("/login")
     await page.getByTestId("email").fill("will@star.fleet")
     await page.getByTestId("password").fill("enterprise")
     await page.getByTestId("submit").click()
@@ -22,7 +22,7 @@ test.describe("Two-factor settings", () => {
     await page.getByTestId("user-menu").click()
     await page.getByTestId("nav-two-factor").click()
 
-    await expect(page).toHaveURL(/\/app\/settings\/two-factor$/)
+    await expect(page).toHaveURL(/\/settings\/two-factor$/)
     await expect(page.getByTestId("two-factor-title")).toBeVisible()
 
     // POST /me/otp on mount generates the secret the URI encodes.
@@ -31,7 +31,7 @@ test.describe("Two-factor settings", () => {
   })
 
   test("serves the qr code as an svg", async ({ page }) => {
-    await page.goto("/app/settings/two-factor")
+    await page.goto("/settings/two-factor")
     await expect(page.getByTestId("provisioning-uri")).toBeVisible()
 
     const response = await page.request.get("/api/v1/me/otp/qrcode")
@@ -41,7 +41,7 @@ test.describe("Two-factor settings", () => {
   })
 
   test("rejects a token the authenticator did not produce", async ({ page }) => {
-    await page.goto("/app/settings/two-factor")
+    await page.goto("/settings/two-factor")
     await expect(page.getByTestId("provisioning-uri")).toBeVisible()
 
     await page.getByTestId("otp-token").fill("000000")

--- a/test/integration/login_test.rb
+++ b/test/integration/login_test.rb
@@ -15,19 +15,19 @@ class LoginTest < ActionDispatch::IntegrationTest
   it "sends /signin to the spa login" do
     get "/signin"
 
-    assert_redirected_to "/app/login"
+    assert_redirected_to "/login"
   end
 
   it "hands over the screen a signed-out visitor asked for" do
     get "/expense_imports/new"
 
-    assert_redirected_to "/app/login?return=%2Fexpense_imports%2Fnew"
+    assert_redirected_to "/login?return=%2Fexpense_imports%2Fnew"
   end
 
   it "keeps the query of the screen it hands over" do
     get "/expense_imports/new?year=2026"
 
-    assert_redirected_to "/app/login?return=%2Fexpense_imports%2Fnew%3Fyear%3D2026"
+    assert_redirected_to "/login?return=%2Fexpense_imports%2Fnew%3Fyear%3D2026"
   end
 
   # The login ends in a page load, so a carried path is fetched with a GET
@@ -38,7 +38,7 @@ class LoginTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to "/signin"
     follow_redirect!
-    assert_redirected_to "/app/login"
+    assert_redirected_to "/login"
   end
 
   # An xhr request never reaches the handover at all: Devise answers it with

--- a/test/integration/spa_auth_links_test.rb
+++ b/test/integration/spa_auth_links_test.rb
@@ -12,30 +12,30 @@ class SpaAuthLinksTest < ActionDispatch::IntegrationTest
   it "forwards a confirmation link with its token" do
     get "/users/confirmation", params: {confirmation_token: "a-token"}
 
-    assert_redirected_to "/app/confirmation?confirmation_token=a-token"
+    assert_redirected_to "/confirmation?confirmation_token=a-token"
   end
 
   it "forwards an unlock link with its token" do
     get "/users/unlock", params: {unlock_token: "a-token"}
 
-    assert_redirected_to "/app/unlock?unlock_token=a-token"
+    assert_redirected_to "/unlock?unlock_token=a-token"
   end
 
   it "forwards a password reset link with its token" do
     get "/users/password/edit", params: {reset_password_token: "a-token"}
 
-    assert_redirected_to "/app/password/edit?reset_password_token=a-token"
+    assert_redirected_to "/password/edit?reset_password_token=a-token"
   end
 
   it "forwards the request forms that carry no token" do
     get "/users/password/new"
-    assert_redirected_to "/app/password/new"
+    assert_redirected_to "/password/new"
 
     get "/users/confirmation/new"
-    assert_redirected_to "/app/confirmation"
+    assert_redirected_to "/confirmation"
 
     get "/users/unlock/new"
-    assert_redirected_to "/app/unlock"
+    assert_redirected_to "/unlock"
   end
 
   # The promise is about the mails themselves, so follow a real one rather
@@ -47,7 +47,7 @@ class SpaAuthLinksTest < ActionDispatch::IntegrationTest
 
     get emailed_path(%r{/users/unlock\?unlock_token=[^"]+})
 
-    assert_match %r{/app/unlock\?unlock_token=.+\z}, response.location
+    assert_match %r{/unlock\?unlock_token=.+\z}, response.location
   end
 
   it "forwards the link a real confirmation mail carries" do
@@ -55,7 +55,7 @@ class SpaAuthLinksTest < ActionDispatch::IntegrationTest
 
     get emailed_path(%r{/users/confirmation\?confirmation_token=[^"]+})
 
-    assert_match %r{/app/confirmation\?confirmation_token=.+\z}, response.location
+    assert_match %r{/confirmation\?confirmation_token=.+\z}, response.location
   end
 
   private def emailed_path(pattern)

--- a/test/integration/spa_catch_all_test.rb
+++ b/test/integration/spa_catch_all_test.rb
@@ -54,10 +54,32 @@ class SpaCatchAllTest < ActionDispatch::IntegrationTest
     assert_equal "text/csv", response.media_type
   end
 
-  # A missing asset is a missing asset, not a screen.
+  # A missing asset is a missing asset, not a screen — whatever it asks for.
   it "does not answer a request for something that is not a page" do
     get "/nope.json", headers: {"Accept" => "application/json"}
-
     assert_response :not_found
+
+    get "/vite/gone-abc123.js", headers: {"Accept" => "*/*"}
+    assert_response :not_found
+  end
+
+  # `*/*` is what a plain `curl` and a `fetch` without an Accept header send.
+  # A screen that only answers a browser is a screen that is hard to debug.
+  it "answers a client that asks for nothing in particular" do
+    get "/login", headers: {"Accept" => "*/*"}
+
+    assert_response :success
+    assert shell?
+  end
+
+  # The paths above are the server's whether or not it has a route for the
+  # one being asked for: a typo under them is a 404, not a screen.
+  it "leaves a typo under a server-owned path a typo" do
+    ["/api/v1/nope", "/api-docs/nope", "/backend/nope", "/cable/nope"].each do |path|
+      get path
+
+      assert_response :not_found, "#{path} came back as #{response.status}"
+      refute shell?, "#{path} came back as the shell"
+    end
   end
 end

--- a/test/integration/spa_catch_all_test.rb
+++ b/test/integration/spa_catch_all_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The SPA owns every path nothing else claims. What "nothing else" means is
+# the point of this test: the API, the docs, the healthcheck, the admin, the
+# exports and the PDFs are not screens, and a request for one of them must
+# not come back as a shell.
+class SpaCatchAllTest < ActionDispatch::IntegrationTest
+  let(:admin) { users :jeanluc }
+
+  def shell?
+    response.body.include?('id="spa"')
+  end
+
+  it "answers a path nothing names with the shell" do
+    get "/expenses/import"
+
+    assert_response :success
+    assert shell?
+  end
+
+  it "leaves the api to the api" do
+    get "/api/v1/me", headers: {"Accept" => "application/json"}
+
+    assert_response :unauthorized
+    refute shell?
+  end
+
+  it "leaves the healthcheck and the docs alone" do
+    get "/up"
+
+    assert_response :success
+    refute shell?
+  end
+
+  it "leaves the admin to the admin" do
+    sign_in admin
+
+    get "/backend/users"
+
+    assert_response :success
+    refute shell?
+  end
+
+  # Same path as the SPA's expenses list, in another format.
+  it "leaves an export in its own format" do
+    sign_in admin
+    admin.account.update_columns(feature_expenses: true)
+
+    get "/expenses.csv"
+
+    assert_response :success
+    assert_equal "text/csv", response.media_type
+  end
+
+  # A missing asset is a missing asset, not a screen.
+  it "does not answer a request for something that is not a page" do
+    get "/nope.json", headers: {"Accept" => "application/json"}
+
+    assert_response :not_found
+  end
+end

--- a/test/integration/spa_cutover_links_test.rb
+++ b/test/integration/spa_cutover_links_test.rb
@@ -2,65 +2,63 @@
 
 require "test_helper"
 
-# The paths the SPA took over still answer, because bookmarks and the links
-# on the screens that have not moved yet point at them. What they carry
-# matters as much as where they lead: a filtered list, a project preselected
-# for a new invoice and the screen to return to after signing in all travel
-# in the query string, which `redirect("/app/…")` drops on the floor.
+# The SPA is mounted at the root, so most of the paths it took over are simply
+# its own — the shell answers them. What still redirects is the handful the
+# SPA does not name the same way it is reached by: Devise's URLs, which sit in
+# mails already sent, and the two the server-rendered user menu links. Those
+# have to keep what they carry — a token, a screen to return to — because
+# `redirect("…")` drops the query string on the floor.
 class SpaCutoverLinksTest < ActionDispatch::IntegrationTest
   let(:id) { "aaaaaaaa-0000-4000-8000-000000000001" }
 
-  it "keeps a list's filters" do
+  it "serves a filtered list without sending the browser anywhere" do
     get "/projects?state=archived"
-    assert_redirected_to "/app/projects?state=archived"
+    assert_response :success
+    assert_select "div#spa"
 
     get "/invoices?year=2026&state=paid"
-    assert_redirected_to "/app/invoices?year=2026&state=paid"
+    assert_response :success
 
     get "/offers?year=2026"
-    assert_redirected_to "/app/offers?year=2026"
+    assert_response :success
   end
 
-  # `projects/show` links a new invoice for the project it is showing, and
-  # the form reads the project out of the query.
-  it "keeps the project a new invoice is for" do
-    get "/invoices/new?project_id=#{id}"
-    assert_redirected_to "/app/invoices/new?project_id=#{id}"
+  it "serves a record's own screen" do
+    ["/invoices/#{id}", "/invoices/#{id}/edit", "/offers/#{id}", "/offers/#{id}/edit",
+      "/customers/#{id}/edit", "/projects/#{id}/edit", "/projects/new", "/timesheet"].each do |path|
+      get path
 
-    get "/offers/new?project_id=#{id}"
-    assert_redirected_to "/app/offers/new?project_id=#{id}"
+      assert_response :success, "#{path} did not reach the shell"
+      assert_select "div#spa"
+    end
   end
 
   it "keeps the screen to come back to after signing in" do
     get "/signin?return=%2Fsettings"
-    assert_redirected_to "/app/login?return=%2Fsettings"
+
+    assert_redirected_to "/login?return=%2Fsettings"
   end
 
-  it "carries a record's id into its own screen" do
-    get "/invoices/#{id}"
-    assert_redirected_to "/app/invoices/#{id}"
+  # The paths Devise puts in its mails, and the two the legacy user menu links.
+  it "leads the paths the SPA names differently to the names it knows" do
+    {
+      "/signin" => "/login",
+      "/users/password/new" => "/password/new",
+      "/users/unlock" => "/unlock",
+      "/users/confirmation" => "/confirmation",
+      "/me/otp" => "/settings/two-factor",
+      "/account/edit" => "/account",
+      "/password/edit" => "/settings/password"
+    }.each do |from, to|
+      get from
 
-    get "/invoices/#{id}/edit"
-    assert_redirected_to "/app/invoices/#{id}/edit"
-
-    get "/offers/#{id}"
-    assert_redirected_to "/app/offers/#{id}"
-
-    get "/offers/#{id}/edit"
-    assert_redirected_to "/app/offers/#{id}/edit"
-
-    get "/customers/#{id}/edit"
-    assert_redirected_to "/app/customers/#{id}/edit"
-
-    get "/projects/#{id}/edit"
-    assert_redirected_to "/app/projects/#{id}/edit"
+      assert_redirected_to to
+    end
   end
 
-  it "leads to the screen itself where there is nothing to carry" do
-    get "/projects/new"
-    assert_redirected_to "/app/projects/new"
+  it "keeps a token on the way" do
+    get "/users/password/edit?reset_password_token=a-token"
 
-    get "/timesheet"
-    assert_redirected_to "/app/timesheet"
+    assert_redirected_to "/password/edit?reset_password_token=a-token"
   end
 end

--- a/test/integration/trial_test.rb
+++ b/test/integration/trial_test.rb
@@ -70,9 +70,8 @@ class TrialTest < ActionDispatch::IntegrationTest
 
       get root_path
 
-      assert_redirected_to spa_path
-      follow_redirect!
       assert_response :success
+      assert_select "div#spa"
     end
   end
 end


### PR DESCRIPTION
Stacked on #1017. Phase C's first item, brought forward: nothing has been
deployed, so the `/app` prefix was scaffolding nobody ever saw — and it cost
every screen a second URL, with the old one redirecting to the new.

The SPA answers the paths the server-rendered screens had, which are the ones
sitting in production bookmarks and in mails already sent, and a catch-all
hands it every page load nothing else claims. The 28 `spa_screen` forwards are
gone.

**What the catch-all steps around**, and what a new integration test pins down
path by path: the API and its docs, the healthcheck, ActionCable, the admin
(including the Sidekiq and Flipper mounts), the CSV and PDF exports, signup,
the three legal pages and the error pages. `rails/` is excluded by hand,
because ActiveStorage draws its routes after `config/routes.rb`. A request
that is not a page load — a missing asset, a stray `.json` — stays a 404
instead of coming back as a shell.

**Redirects are left only where the SPA's own name differs from the path it is
reached by**: Devise's `/users/password/edit` and friends, which carry tokens
in the query, and `/signin`, `/account/edit`, `/password/edit` and `/me/otp`,
which the server-rendered user menu links.

Two things fall out of it:

- The root path renders the shell for a signed-in visitor rather than
  redirecting into a prefix that no longer exists. A signed-out visitor still
  gets the welcome page — which the shell test now asserts explicitly, since
  that is what `/` means for a visitor.
- vue-router gained the 404 screen it never had: with the prefix gone, a typo
  reaches the SPA rather than the server's error page.

Verified: 466 ruby runs, 262 vitest, 120 e2e, `vue-tsc` and rubocop clean.
Fourteen e2e tests that used to assert a forward now assert that the path is
served, and are named accordingly. 🤖