### PR TITLE
fix(spa): draw the server's path boundary on segments

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -196,10 +196,11 @@ Rails.application.routes.draw do
 
   root to: "base#index"
 
-  # The path space the server keeps, whether or not a route above claims the
-  # exact path: a typo under any of these is a 404, not a screen. `rails/` is
-  # ActiveStorage's, which the framework draws after this file.
-  server_owned_paths = %w[/api/ /api-docs /backend/ /cable /rails/ /up]
+  # The first path segments the server keeps, whether or not a route above
+  # claims the exact path: a typo under any of them is a 404, not a screen.
+  # `rails` is ActiveStorage's, which the framework draws after this file.
+  # Compared segment by segment, so `/api` counts and `/apiary` does not.
+  server_owned_roots = %w[api api-docs backend cable rails up]
 
   # The SPA owns the rest: it is the app now, so a path nothing above claims
   # is one of its screens — or one of its screens' sub-paths, which it alone
@@ -215,6 +216,6 @@ Rails.application.routes.draw do
 
     (format.html? || format.to_s == "*/*") &&
       File.extname(request.path).empty? &&
-      server_owned_paths.none? { |prefix| request.path.start_with?(prefix) }
+      server_owned_roots.exclude?(request.path.split("/")[1])
   }
 end

--- a/test/integration/spa_catch_all_test.rb
+++ b/test/integration/spa_catch_all_test.rb
@@ -75,11 +75,22 @@ class SpaCatchAllTest < ActionDispatch::IntegrationTest
   # The paths above are the server's whether or not it has a route for the
   # one being asked for: a typo under them is a 404, not a screen.
   it "leaves a typo under a server-owned path a typo" do
-    ["/api/v1/nope", "/api-docs/nope", "/backend/nope", "/cable/nope"].each do |path|
+    ["/api", "/api/v1/nope", "/api-docs/nope", "/backend/nope", "/cable/nope", "/rails/nope"].each do |path|
       get path
 
       assert_response :not_found, "#{path} came back as #{response.status}"
       refute shell?, "#{path} came back as the shell"
+    end
+  end
+
+  # Segment by segment, or a screen whose name merely starts like one of them
+  # would be unreachable.
+  it "keeps a screen that only reads like a server path" do
+    ["/apiary", "/cablefoo", "/upstream"].each do |path|
+      get path
+
+      assert_response :success, "#{path} came back as #{response.status}"
+      assert shell?, "#{path} did not reach the shell"
     end
   end
 end


### PR DESCRIPTION
The P1 from #1019's review, which arrived while that PR was already in the
merge queue and could no longer be pushed to.

The list of paths the server keeps compared strings, so it was wrong at both
ends: `/api` did not match the entry `/api/` and came back as a 200 shell
instead of a 404, while `/cablefoo` and `/upstream` matched `/cable` and `/up`
and were refused as if they belonged to the server. It is the first path
segment that decides, so that is what it compares now.

Measured against the running app: `/api` and `/api/v1/nope` are 404s,
`/apiary`, `/cablefoo` and `/upstream` reach the shell, `/login` still does.
The catch-all test covers both ends.

483 ruby runs, rubocop clean. 🤖