### PR TITLE
test(spa): cover the healthcheck's subtree in the catch-all test

### DIFF
--- a/test/integration/spa_catch_all_test.rb
+++ b/test/integration/spa_catch_all_test.rb
@@ -75,7 +75,8 @@ class SpaCatchAllTest < ActionDispatch::IntegrationTest
   # The paths above are the server's whether or not it has a route for the
   # one being asked for: a typo under them is a 404, not a screen.
   it "leaves a typo under a server-owned path a typo" do
-    ["/api", "/api/v1/nope", "/api-docs/nope", "/backend/nope", "/cable/nope", "/rails/nope"].each do |path|
+    ["/api", "/api/v1/nope", "/api-docs/nope", "/backend/nope", "/cable/nope", "/rails/nope",
+      "/up/nope"].each do |path|
       get path
 
       assert_response :not_found, "#{path} came back as #{response.status}"


### PR DESCRIPTION
The P2 from #1020's review, which arrived while that PR was already in the
merge queue.

`/up` itself is matched by the healthcheck route before the catch-all's
constraint ever runs, so the existing case says nothing about whether that
root is still reserved. `/up/nope` does.

Test-only. 9 runs, 34 assertions. 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Confirmed that invalid healthcheck paths return a 404 response instead of the SPA shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->