### PR TITLE
feat(api): report what the backend's screens read

### DIFF
--- a/app/api_components/v1/schemas/backend_stats.rb
+++ b/app/api_components/v1/schemas/backend_stats.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    # The numbers the backend dashboard prints beside its lists.
+    class BackendStats
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          usersCount: {type: :integer},
+          accountsCount: {type: :integer}
+        },
+        additionalProperties: false,
+        required: %w[usersCount accountsCount]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/backend_user.rb
+++ b/app/api_components/v1/schemas/backend_user.rb
@@ -17,6 +17,7 @@ module V1
           enabled: {type: [:boolean, :null]},
           confirmed: {type: :boolean},
           accountId: {type: :string, format: :uuid},
+          currentSignInAt: {type: [:string, :null], format: "date-time"},
           createdAt: {type: :string, format: "date-time"},
           updatedAt: {type: :string, format: "date-time"}
         },

--- a/app/controllers/api/v1/backend/stats_controller.rb
+++ b/app/controllers/api/v1/backend/stats_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Backend
+      # What the backend dashboard shows next to its list of the latest
+      # users: how many there are in total, across every account.
+      class StatsController < BaseController
+        def show
+          @users_count = ::User.count
+          @accounts_count = ::Account.count
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/backend/users_controller.rb
+++ b/app/controllers/api/v1/backend/users_controller.rb
@@ -11,7 +11,7 @@ module Api
         after_action -> { pagination_header(:users) }, only: [:index]
 
         def index
-          @users = paginate(::User.all.order(created_at: :desc, id: :desc))
+          @users = paginate(::User.all.order(*order_clause))
         end
 
         def show
@@ -57,6 +57,23 @@ module Api
             render json: {message: I18n.t(:"messages.user.send_welcome.success")}
           else
             render json: ValidationError.new("user.send_welcome", @user.errors), status: :bad_request
+          end
+        end
+
+        # The columns the server-rendered list let you sort by. Written as
+        # order hashes rather than SQL, so the parameter cannot reach the
+        # ORDER BY even in principle. `id` closes every order: emails and
+        # timestamps repeat, and offset paging over a tie can show a row
+        # twice or skip it.
+        private def order_clause
+          direction = (params[:direction] == "asc") ? :asc : :desc
+
+          case params[:sort]
+          when "id" then [{id: direction}]
+          when "email" then [{email: direction}, {id: :desc}]
+          when "admin" then [{admin: direction}, {id: :desc}]
+          when "current_sign_in_at" then [{current_sign_in_at: direction}, {id: :desc}]
+          else [{created_at: direction}, {id: :desc}]
           end
         end
 

--- a/app/views/api/v1/backend/stats/show.json.jbuilder
+++ b/app/views/api/v1/backend/stats/show.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.users_count @users_count
+json.accounts_count @accounts_count

--- a/app/views/api/v1/backend/users/_show.json.jbuilder
+++ b/app/views/api/v1/backend/users/_show.json.jbuilder
@@ -7,5 +7,6 @@ json.admin user.admin
 json.enabled user.enabled
 json.confirmed user.confirmed_at.present?
 json.account_id user.account_id
+json.current_sign_in_at user.current_sign_in_at
 json.created_at user.created_at
 json.updated_at user.updated_at

--- a/config/routes/api_v1_routes.rb
+++ b/config/routes/api_v1_routes.rb
@@ -31,6 +31,8 @@ v1_api_routes = lambda do
   resource :dashboard, only: %i[show], controller: :dashboard
 
   namespace :backend do
+    resource :stats, only: [:show], controller: :stats
+
     resources :accounts, only: %i[index show create update destroy]
 
     resources :users, only: %i[index show create update destroy] do

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -270,6 +270,31 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
+  "/backend/stats":
+    get:
+      summary: How much there is of everything
+      tags:
+      - Backend
+      operationId: backendStats
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BackendStats"
+        '403':
+          description: not an admin
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/backend/users":
     get:
       summary: Users across every account
@@ -279,6 +304,27 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/PageParameter"
       - "$ref": "#/components/parameters/PerPageParameter"
+      - name: sort
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - id
+          - email
+          - admin
+          - current_sign_in_at
+          - created_at
+        description: The columns the backend list sorts by. Anything else is the newest
+          first.
+      - name: direction
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
       responses:
         '200':
           description: successful
@@ -3458,6 +3504,18 @@ components:
       items:
         "$ref": "#/components/schemas/BackendAccount"
       title: BackendAccounts
+    BackendStats:
+      type: object
+      properties:
+        usersCount:
+          type: integer
+        accountsCount:
+          type: integer
+      additionalProperties: false
+      required:
+      - usersCount
+      - accountsCount
+      title: BackendStats
     BackendUser:
       type: object
       properties:
@@ -3483,6 +3541,11 @@ components:
         accountId:
           type: string
           format: uuid
+        currentSignInAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
         createdAt:
           type: string
           format: date-time

--- a/test/integration/api/v1/backend_stats_test.rb
+++ b/test/integration/api/v1/backend_stats_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+module Api
+  module V1
+    class BackendStatsTest < ActionDispatch::IntegrationTest
+      include OpenapiRuby::Adapters::Minitest::DSL
+
+      openapi_schema :"v1/schema"
+
+      api_path "/backend/stats" do
+        get("How much there is of everything") do
+          operationId "backendStats"
+          tags "Backend"
+          produces "application/json"
+
+          response(200, "successful") do
+            schema ::V1::Schemas::BackendStats
+          end
+
+          response(403, "not an admin") do
+            schema ::V1::Schemas::StandardError
+          end
+
+          response(401, "unauthorized") do
+            schema ::V1::Schemas::StandardError
+          end
+        end
+      end
+
+      let(:admin) { users :jeanluc }
+
+      it "is unauthorized when signed out" do
+        assert_api_response :get, 401
+      end
+
+      it "is forbidden for a non-admin" do
+        sign_in users(:data)
+
+        assert_api_response :get, 403
+      end
+
+      # Across every account, which is the point of the backend.
+      it "counts the users and the accounts" do
+        sign_in admin
+
+        assert_api_response :get, 200 do
+          assert_equal User.count, parsed_body["usersCount"]
+          assert_equal Account.count, parsed_body["accountsCount"]
+        end
+      end
+    end
+  end
+end

--- a/test/integration/api/v1/backend_users_test.rb
+++ b/test/integration/api/v1/backend_users_test.rb
@@ -18,6 +18,12 @@ module Api
           parameter "$ref": "#/components/parameters/PageParameter"
           parameter "$ref": "#/components/parameters/PerPageParameter"
 
+          parameter name: "sort", in: :query, required: false,
+            schema: {type: :string, enum: %w[id email admin current_sign_in_at created_at]},
+            description: "The columns the backend list sorts by. Anything else is the newest first."
+          parameter name: "direction", in: :query, required: false,
+            schema: {type: :string, enum: %w[asc desc]}
+
           response(200, "successful") do
             schema ::V1::Schemas::BackendUsers
             header "Link", schema: {type: :string}, description: "RFC 8288 pagination links."
@@ -97,6 +103,26 @@ module Api
             } do
               refute parsed_body["confirmed"]
             end
+          end
+        end
+
+        # The server-rendered list sorted by five columns; the endpoint takes
+        # the same set and falls back to the newest first.
+        it "sorts by the columns the list offers" do
+          assert_api_response :get, 200, params: {sort: "email", direction: "asc", perPage: "all"} do
+            emails = parsed_body.map { |user| user["email"] }
+
+            assert_equal emails.sort, emails
+          end
+        end
+
+        it "says when a user was last seen" do
+          member.update_columns(current_sign_in_at: Time.zone.parse("2026-03-04T10:00:00Z"))
+
+          assert_api_response :get, 200, params: {perPage: "all"} do
+            user = parsed_body.find { |entry| entry["id"] == member.id }
+
+            assert_equal member.reload.current_sign_in_at, Time.zone.parse(user["currentSignInAt"])
           end
         end
 


### PR DESCRIPTION
The rest of the API for the backend admin, whose accounts endpoints landed in
#1016. Three things the screens would otherwise have to guess at:

- **`currentSignInAt`** on the admin-facing user. It is the third column of
  the server-rendered list, and most of why an admin looks a user up at all.
- **Sorting** on `GET /backend/users`, by the columns that list offered: id,
  email, admin, last sign-in, created. Written as order hashes rather than
  SQL, so the parameter cannot reach the ORDER BY, and `id` closes every
  order — emails and timestamps repeat, and offset paging over a tie can show
  a row twice or skip it.
- **`GET /backend/stats`** — how many users and accounts there are. The
  dashboard prints the user count beside its list of the latest ten, and the
  pagination header carries links, not totals.

Next PR ports the four screens (dashboard, users list + form, accounts list +
form), deletes the ERB backend and takes `/backend` out of the paths the
catch-all reserves for the server.

488 ruby runs, rubocop clean, schema and client regenerated. 🤖