### PR TITLE
fix(spa): make a dropdown row the control, not its label

### DIFF
--- a/app/frontend/entrypoints/spa.css
+++ b/app/frontend/entrypoints/spa.css
@@ -248,6 +248,23 @@
     transition: all 0.3s;
   }
 
+  /* Where the entry is a link or a button, that is what carries the padding:
+     the row is the control, so clicking beside the label does what clicking
+     the label does. Bootstrap's own `.dropdown-menu > li > a` was the anchor
+     all the way out to the edges. */
+  .bs-dropdown-item:has(> a, > button) {
+    padding: 0;
+  }
+
+  .bs-dropdown-item > a,
+  .bs-dropdown-item > button {
+    display: block;
+    width: 100%;
+    padding: 3px 20px;
+    color: inherit;
+    text-align: left;
+  }
+
   .bs-dropdown-item:hover,
   .bs-dropdown-item.is-active {
     background-color: var(--color-surface-muted);

--- a/test/e2e/Spa.spec.ts
+++ b/test/e2e/Spa.spec.ts
@@ -30,6 +30,26 @@ test.describe("SPA shell", () => {
     await expect(page.getByTestId("submit")).toBeVisible()
   })
 
+  // A dropdown row is the control, not its label: the padding used to sit on
+  // the row while the link covered the text alone, so a click an inch to the
+  // right of "Account" did nothing.
+  test("answers a click anywhere on a menu row", async ({ page }) => {
+    await page.goto("/login")
+    await page.getByTestId("email").fill("will@star.fleet")
+    await page.getByTestId("password").fill("enterprise")
+    await page.getByTestId("submit").click()
+    await expect(page.getByTestId("dashboard-title")).toBeVisible()
+
+    await page.getByTestId("user-menu").click()
+
+    const row = page.getByTestId("nav-account")
+    const box = await row.boundingBox()
+
+    await page.mouse.click((box?.x ?? 0) + (box?.width ?? 0) - 6, (box?.y ?? 0) + (box?.height ?? 0) / 2)
+
+    await expect(page).toHaveURL(/\/account$/)
+  })
+
   // The bar the server-rendered pages get from Turbo Drive. It waits half a
   // second first, so the request has to be held up to see it at all.
   test("draws the loading bar while a request is in flight", async ({ page }) => {


### PR DESCRIPTION
Reported as "the user menu does nothing", and it turned out to be the hit
area: the padding sat on the row (`.bs-dropdown-item`) while the link or
button inside covered its text alone. A click an inch to the right of
"Account" landed on the padding and did nothing at all.

This is the same mistake the list rows had — the row hovered as one thing and
answered as another — and it affects every dropdown built from
`UiDropdownItem`: the user menu, and the row actions on the invoice, offer and
project lists. The entry now carries the padding and fills the row, the way
Bootstrap's own `.dropdown-menu > li > a` did.

`:has(> a, > button)` keeps the filter dropdowns working, where the row itself
takes the click and there is no inner control to hand the padding to.

Covered by a Playwright case that clicks six pixels from the row's right edge,
which is what a person does. 274 vitest, the shell and the three list specs
green.

Found while chasing a report I could not reproduce by clicking the labels —
worth remembering: "does nothing" from a person usually means they aimed
where I did not. 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dropdown menu rows so links and buttons occupy the full row, making the entire row clickable.
  - Preserved expected styling, including spacing, alignment, and text color.

- **Tests**
  - Added end-to-end coverage confirming that clicking anywhere on an account menu row navigates correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->