### PR TITLE
fix(spa): draw the chosen tab as the card it was

### DIFF
--- a/app/frontend/components/ui/UiNavTabs.vue
+++ b/app/frontend/components/ui/UiNavTabs.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
-// `.nav-tabs` as the preview used them: the active tab joins the panel below
-// it by painting over the shared border.
+// `.nav-tabs` as the server-rendered screens had them: the chosen tab is a
+// white card with a border on three sides, sitting on the row's own line,
+// which it paints over along its lower edge.
+//
+// The border colour belongs to the state, not to the base: Tailwind resolves
+// two utilities for one property by their order in the stylesheet, not by the
+// order they are written in, and `border-transparent` in the base was
+// beating `border-rule-strong` here — leaving the chosen tab with no card at
+// all, only a gap in the line.
 interface Tab {
   key: string
   label: string
@@ -16,11 +23,11 @@ const emit = defineEmits<{select: [string]}>()
     <li v-for="tab in tabs" :key="tab.key" class="-mb-px">
       <button
         type="button"
-        class="mr-0.5 block rounded-t-bs border border-transparent px-[15px] py-2.5 leading-[1.428571429]"
+        class="mr-0.5 block rounded-t-bs border px-[15px] py-2.5 leading-[1.428571429]"
         :class="
           tab.key === active
             ? 'border-rule-strong border-b-surface bg-surface text-field'
-            : 'text-brand hover:bg-rule'
+            : 'border-transparent text-brand hover:border-rule hover:border-b-rule-strong'
         "
         :data-test="`tab-${tab.key}`"
         @click="emit('select', tab.key)"

--- a/test/e2e/ProjectDetail.spec.ts
+++ b/test/e2e/ProjectDetail.spec.ts
@@ -91,6 +91,20 @@ test.describe("Project detail", () => {
     expect(colours.top).toBe("rgb(221, 221, 221)")
     // The lower edge paints over the row's line, so the card joins the page.
     expect(colours.bottom).toBe("rgb(255, 255, 255)")
+
+    // Hovering an unchosen tab draws `#eee #eee #ddd`, which is the same
+    // order-sensitive pairing and would fail the same way.
+    const other = page.getByTestId("tab-offers")
+    await other.hover()
+
+    const hovered = await other.evaluate((node) => {
+      const style = getComputedStyle(node)
+
+      return {top: style.borderTopColor, bottom: style.borderBottomColor}
+    })
+
+    expect(hovered.top).toBe("rgb(238, 238, 238)")
+    expect(hovered.bottom).toBe("rgb(221, 221, 221)")
   })
 
   test("opens the tab the url names", async ({ page }) => {

--- a/test/e2e/ProjectDetail.spec.ts
+++ b/test/e2e/ProjectDetail.spec.ts
@@ -72,6 +72,27 @@ test.describe("Project detail", () => {
     await expect(page.getByTestId("timers-calendar")).toBeVisible()
   })
 
+  // The chosen tab is a card: a border on three sides, joined to the row's
+  // own line. Two Tailwind utilities for one property resolve by their order
+  // in the stylesheet, not by the order they are written in, and the base's
+  // `border-transparent` was quietly winning — leaving a gap in the line
+  // where the card should be.
+  test("draws the chosen tab as a card", async ({ page }) => {
+    const id = await projectId()
+    await page.goto(`/projects/${id}`)
+
+    const chosen = page.getByTestId("tab-timers")
+    const colours = await chosen.evaluate((node) => {
+      const style = getComputedStyle(node)
+
+      return {top: style.borderTopColor, bottom: style.borderBottomColor}
+    })
+
+    expect(colours.top).toBe("rgb(221, 221, 221)")
+    // The lower edge paints over the row's line, so the card joins the page.
+    expect(colours.bottom).toBe("rgb(255, 255, 255)")
+  })
+
   test("opens the tab the url names", async ({ page }) => {
     const id = await projectId()
     await page.goto(`/projects/${id}#tasks`)


### PR DESCRIPTION
Reported as "the tabs don't look like the original", and measured against it:
I rendered the server-rendered markup (`ul.nav.nav-tabs` inside
`.nav-tabs-list.nav-tabs-full-width`) against the still-built
`application.css`, screenshotted both, and the difference was the chosen tab.
It should be a white card with a border on three sides, sitting on the row's
own line and painting over it along its lower edge. The port had no card at
all — only a gap in the line where it should be.

The cause is worth writing down, because it is silent: **Tailwind resolves two
utilities for one property by their order in the generated stylesheet, not by
the order they are written on the element.** `.border-rule-strong` is emitted
at byte 23390 and `.border-transparent` at 23512, so the base's
`border-transparent` beat the chosen tab's `border-rule-strong`, while
`.border-b-surface` (23615) still won the lower edge — which is exactly the
gap-without-a-card that was visible. The border colour now lives in the state
rather than in the base, so only one utility applies per element.

Hovering an unchosen tab draws `#eee #eee #ddd` as Bootstrap did, instead of
filling the tab grey.

Swept the other components for the same shape: `UiButton` keeps every border
colour in its variant strings and its base carries only `border`, so it is
clean. This was the only one.

Covered by a Playwright case that reads the chosen tab's computed border
colours — the check that catches an ordering flip, which no screenshot test
would. 274 vitest, the project, invoice and settings specs green. 🤖