### PR TITLE
docs: describe the app that exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,8 @@ rendered as PDFs and emailed.
 - **Auth** Devise + devise-two-factor (v6 schema); JWT for API
 - **Authz** CanCanCan
 - **Templating** Vue 3 SFCs for every screen; ERB for the shell, the
-  mailers, the PDF templates and the three public pages that have not
-  moved (welcome, signup, the legal pages)
+  mailers, the PDF templates and the five public pages that have not
+  moved (`/`, `/signup`, `/impressum`, `/privacy`, `/terms`)
 - **PDF** Grover (puppeteer + Google Chrome)
 - **Monitoring** AppSignal — the Ruby agent covers Rails + Sidekiq
   (`config/appsignal.rb`), and `@appsignal/javascript` covers the Vue
@@ -34,7 +34,7 @@ rendered as PDFs and emailed.
   production
 - **Frontend toolchain** Vite (`vite_rails`) with TS entrypoints under
   `app/frontend/`. The legacy Sprockets bundle is still built, but only
-  the three remaining ERB pages load it — it is what keeps jQuery,
+  the five remaining ERB pages load it — it is what keeps jQuery,
   Bootstrap's JS and the last CoffeeScript alive.
 - **CSS** Tailwind 4 via `@tailwindcss/vite`. `spa.css` carries its own
   preflight and a set of `bs-*` classes measured off the
@@ -42,7 +42,7 @@ rendered as PDFs and emailed.
   disturb Bootstrap 3 on the pages that still use it.
 - **JS framework** Vue 3 + vue-router, which owns the whole path space.
   Turbo Drive and Stimulus are still loaded by the legacy bundle and
-  matter only on the three ERB pages.
+  matter only on the five ERB pages.
 
 ### Migrating toward
 
@@ -87,7 +87,7 @@ islands) and is history.
 - `/impressum`, `/privacy`, `/terms` — empty views that answer 200 with
   an empty body, linked from nowhere.
 
-Those three are what keeps the legacy pipeline alive. Until they are
+Those five pages are what keeps the legacy pipeline alive. Until they are
 settled, **do not delete `app/assets/`**, and leave Tailwind's preflight
 off in `tailwind.css`. What they still rely on: Turbo Drive for
 navigation, the `turbo:load → turbolinks:load` shim in `application.ts`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,9 @@ rendered as PDFs and emailed.
   `:redis_cache_store`
 - **Auth** Devise + devise-two-factor (v6 schema); JWT for API
 - **Authz** CanCanCan
-- **Templating** ERB (every view; haml + slim removed in Phase 3)
+- **Templating** Vue 3 SFCs for every screen; ERB for the shell, the
+  mailers, the PDF templates and the three public pages that have not
+  moved (welcome, signup, the legal pages)
 - **PDF** Grover (puppeteer + Google Chrome)
 - **Monitoring** AppSignal — the Ruby agent covers Rails + Sidekiq
   (`config/appsignal.rb`), and `@appsignal/javascript` covers the Vue
@@ -31,12 +33,16 @@ rendered as PDFs and emailed.
 - **Storage** ActiveStorage on DigitalOcean Spaces (S3-compatible) in
   production
 - **Frontend toolchain** Vite (`vite_rails`) with TS entrypoints under
-  `app/frontend/`, alongside the legacy Sprockets + Terser bundle
-  which still ships jQuery / CoffeeScript / AngularJS until Phase 9.
-- **CSS** Tailwind 4 via `@tailwindcss/vite` (preflight off so it
-  coexists with Bootstrap 3 until Phase 9)
-- **JS framework** Hotwire — Turbo Drive owns navigation, Stimulus
-  controllers auto-register from `app/frontend/controllers/*_controller.ts`
+  `app/frontend/`. The legacy Sprockets bundle is still built, but only
+  the three remaining ERB pages load it — it is what keeps jQuery,
+  Bootstrap's JS and the last CoffeeScript alive.
+- **CSS** Tailwind 4 via `@tailwindcss/vite`. `spa.css` carries its own
+  preflight and a set of `bs-*` classes measured off the
+  server-rendered screens; `tailwind.css` omits preflight so it cannot
+  disturb Bootstrap 3 on the pages that still use it.
+- **JS framework** Vue 3 + vue-router, which owns the whole path space.
+  Turbo Drive and Stimulus are still loaded by the legacy bundle and
+  matter only on the three ERB pages.
 
 ### Migrating toward
 
@@ -47,63 +53,69 @@ rendered as PDFs and emailed.
 
 ### Frontend modernization in flight
 
-The frontend is legacy and being replaced. **Don't add new code to the
-legacy stack** — if you must touch a screen, prefer the smallest
-in-place change. New features go through Vite (TS + Tailwind +
-Hotwire). See `docs/frontend-migration-plan.md` for the phased plan.
+The app is a Vue SPA. Every screen behind a login has moved; what is left
+server-rendered is deliberate or not yet decided. `docs/vue-spa-migration-plan.md`
+is the plan of record — `docs/frontend-migration-plan.md` describes the
+phases that preceded it (Vite, Tailwind, ERB conversion, Turbo, Vue
+islands) and is history.
 
-Done (Phases 1–4 + Phase 5 in progress):
+**Where things are**
 
-- Phase 1 — Vite installed alongside Sprockets (#859)
-- Phase 2 — Tailwind 4 alongside Bootstrap 3, preflight off (#860)
-- Phase 3 — every haml/slim template converted to ERB; haml + slim
-  gems dropped (#861–#870)
-- Phase 4 — Turbo Drive + Stimulus baseline; Turbolinks gone
-  (#871, #872)
-- Phase 5 — Turbo Frames on CRUD index pages
-  (projects #873, offers #874, invoices #875) + customer edit
-  form (#888)
-- Phase 6a — Vue 3 islands foundation: `vue`, `@vitejs/plugin-vue`,
-  `app/frontend/islands/<name>/`, the `mountIslands(registry)`
-  helper, and a `hello` smoke-test SFC. Actual timesheet +
-  timers-calendar ports come next.
-- Phase 8 — Cypress 12 → Playwright + cypress-on-rails bridge;
-  cleared the last 11 dev-only npm vulns
+- `app/frontend/pages/<domain>/` — the screens, one folder per domain,
+  with their Vitest specs beside them.
+- `app/frontend/components/ui/` — the shared `Ui*` components. They are
+  measured ports of Bootstrap 3, not a new design system: `spa.css`
+  holds the values, with a comment naming the partial each came from.
+- `app/frontend/plugins/router.ts` — every route. `meta.requiresAuth`
+  gates a screen, `meta.requiresAdmin` re-reads who you are, and
+  `meta.backend` swaps the chrome for the admin's own.
+- `app/frontend/services/api/` — generated, gitignored, never edited.
 
-Still legacy (to be removed in later phases):
+**Still server-rendered, on purpose**
 
-- Bootstrap 3 (EOL 2019) + bootstrap-sass + bourbon — Phase 9
-- AngularJS (EOL 2021) under `app/assets/javascripts/angular/` —
-  Phase 7, after Vue islands (Phase 6) replace timesheet + project
-  timers calendar
-- jQuery + jquery_ujs — Phase 9 (after the remaining `[data-method]`
-  / `[data-notyConfirm]` flows move to Turbo + Stimulus)
-- CoffeeScript (`*.coffee` files, `coffee-rails` gem) — Phase 9
-- Sprockets `//= require` manifests — Phase 9
-- bower-rails — Phase 7
-- i18n-js v3 — Phase 10
+- The PDFs (`app/views/invoices/pdf`, `offers/pdf`, `expenses/index.pdf`)
+  and the CSV exports. The SPA links them.
+- The mailers.
+- Sidekiq (`/backend/workers`) and Flipper (`/backend/flipper`).
 
-### Hotwire conventions
+**Still server-rendered, undecided**
 
-- **Turbo Drive** is enabled globally. Opt out with `data-turbo="false"`
-  on a link or its container.
-- **Turbo Frames** wrap list/filter/pagination regions on index pages
-  (see `app/views/{projects,offers,invoices}/index.html.erb`). Frame
-  id matches the wrapper on both the initial render and the
-  subsequent partial response; the controller doesn't need a special
-  branch.
-- **`data-turbo-method`** is the Turbo replacement for the classic
-  Rails `link_to ..., method: :put|:delete`. Use `data: { turbo_method:
-  :put }` in `link_to` calls.
-- **`turbo:load → turbolinks:load` shim** in `application.ts` re-fires
-  the legacy event so existing CoffeeScript that listens for
-  `turbolinks:load` keeps working under Turbo navigation. Delegate
-  event handlers to `document` if they need to survive Turbo Frame
-  swaps (see `app/assets/javascripts/helpers/noty.coffee` for the
-  pattern).
-- **Stimulus controllers** live in `app/frontend/controllers/`. File
-  `tabs_controller.ts` exporting a default `Controller` subclass
-  auto-registers as `data-controller="tabs"`.
+- `/` for a signed-out visitor on the apex host — the welcome page, with
+  its pricing table from `Plan`.
+- `/signup`, which drives Stripe Checkout through
+  `app/assets/javascripts/app/signup.coffee.erb`.
+- `/impressum`, `/privacy`, `/terms` — empty views that answer 200 with
+  an empty body, linked from nowhere.
+
+Those three are what keeps the legacy pipeline alive. Until they are
+settled, **do not delete `app/assets/`**, and leave Tailwind's preflight
+off in `tailwind.css`. What they still rely on: Turbo Drive for
+navigation, the `turbo:load → turbolinks:load` shim in `application.ts`,
+and `data-turbo-method` in place of the classic `link_to ..., method:`.
+
+### SPA conventions
+
+- **The API comes first, and its schema is the tests.** Declare an
+  endpoint in a Minitest DSL spec under `test/integration/api/v1/`, then
+  `RAILS_ENV=test rake openapi_ruby:generate` writes `swagger/v1/schema.yaml`
+  and `pnpm run generate-api-client` turns it into the hooks under
+  `app/frontend/services/api/`. A route and an action without a DSL
+  declaration are unreachable from the SPA — that has bitten twice.
+- **Rails owns a path or the SPA does.** `config/routes.rb` ends in a
+  catch-all that hands every page load to the shell; the list of first
+  path segments above it (`api`, `api-docs`, `backend`'s two mounts,
+  `cable`, `rails`, `up`) is what the server keeps. A path that answers
+  a non-page request — an export, a PDF — is declared before it.
+- **A screen's state lives in the URL.** Filters, sorting and paging are
+  query parameters, so a filtered list is a link someone can send.
+- **Three test layers, and they do different jobs.** Vitest for a
+  component's logic against a stubbed adapter, the Minitest DSL specs
+  for the contract, Playwright for the flow through a real server. A
+  screen port lands with all three.
+- **Measure, do not guess, when porting a look.** The server-rendered
+  stylesheet is still built: render the old markup against
+  `application.css`, screenshot it, and match. Two bugs got through on a
+  guess — a chart whose labels wrapped and a tab that had no card.
 
 ## Project structure
 
@@ -112,13 +124,14 @@ reckoning/
 ├── app/
 │   ├── controllers/       # Rails controllers (API in api/v1/)
 │   ├── models/            # ActiveRecord models
-│   ├── views/             # ERB templates
+│   ├── views/             # ERB: the shell, mailers, PDFs, public pages
 │   ├── helpers/           # view helpers
 │   ├── mailers/           # mailers
 │   ├── workers/           # Sidekiq workers
 │   ├── services/          # service objects (invoice/offer/import logic)
 │   ├── validators/        # custom AR validators
-│   └── assets/            # legacy Sprockets pipeline (being replaced)
+│   ├── frontend/          # the Vue SPA (pages, components, stores, api)
+│   └── assets/            # legacy Sprockets, for the public pages only
 ├── config/
 │   ├── routes.rb          # main router (delegates to routes/*.rb)
 │   ├── routes/            # api_routes, etc.

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,6 @@
 //= require pickadate/lib/themes/default.date
 //= require pickadate/lib/themes/default.time
 //= require nprogress
-//= require nvd3
 //= require awesome-bootstrap-checkbox
 //= require selectize/dist/css/default
 //= require_self

--- a/docs/vue-spa-migration-plan.md
+++ b/docs/vue-spa-migration-plan.md
@@ -696,14 +696,15 @@ Only once B8 has landed and stabilized.
       been deployed, so the SPA answers the paths the server-rendered screens
       had. The reserved first segments are listed beside the route.
 - [x] Delete `app/assets/javascripts/angular/`, `app/views/templates/`,
-      `TemplatesController`, the vendored Highcharts copy and the d3 / nvd3 /
-      underscore requires.
+      `TemplatesController`, the vendored Highcharts copy, and the d3 / nvd3 /
+      underscore requires from both manifests — the stylesheet kept its own
+      `//= require nvd3` until the review of this note caught it.
 - [ ] The rest of `app/assets/` — blocked, not forgotten: the welcome page
       needs jQuery and Bootstrap's modal, and `/signup` drives Stripe Checkout
       from `signup.coffee.erb`. Those two, and the three empty legal pages,
       are a product decision rather than a port.
-- [ ] Delete `app/assets/javascripts/`, `app/assets/stylesheets/`,
-      `app/views/templates/`, `TemplatesController`, `vendor/` bower bundles.
+- [ ] Delete what is left of `app/assets/javascripts/` and
+      `app/assets/stylesheets/`, and the `vendor/` bower bundles.
 - [ ] Delete `app/frontend/controllers/*_controller.ts` (Stimulus) and
       `app/frontend/lib/mount-islands.ts`.
 - [ ] Drop gems: `bower-rails`, `bootstrap-sass`, `bourbon`, `sass-rails`,

--- a/docs/vue-spa-migration-plan.md
+++ b/docs/vue-spa-migration-plan.md
@@ -563,18 +563,20 @@ Vue page + components, vue-query hooks from the generated client, VeeValidate
 for the flow, then **the Rails route is repointed at the SPA and the old ERB
 views + Angular/jQuery/Coffee for that screen are deleted in the same PR**.
 
-- [ ] **B2** Login / signup / password reset / 2FA. Confirmation and unlock
-      are part of this surface too — see the API gap note below.
-- [ ] **B3** Customers list + form; Projects list, detail, form; Tasks.
-- [ ] **B4** Timesheet (day/week/month) — reuses `app/frontend/islands/timesheet/`
+- [x] **B2** ✅ Login / password reset / 2FA, plus confirmation and unlock —
+      see the API gap note below. Signup stays server-rendered for now: it
+      drives Stripe Checkout.
+- [x] **B3** ✅ Customers list + form; Projects list, detail, form; Tasks.
+- [x] **B4** ✅ Timesheet (day/week/month) — reuses `app/frontend/islands/timesheet/`
       SFCs, promoted to `frontend/pages/timesheet/`; deletes
       `app/assets/javascripts/angular/timesheet/`.
-- [ ] **B5** Timers calendar — reuses `islands/timers-calendar/`; deletes
-      `angular/timers_calendar/`.
-- [ ] **B6** Invoices list + detail + **line-item editor** (the other
-      genuinely complex screen); PDF links point at the existing Rails routes.
-- [ ] **B7** Offers list + detail + line-item editor + state transitions.
-- [ ] **B8** Expenses + expense import wizard + dashboard + settings tabs +
+- [x] **B5** ✅ Timers calendar — the island is the project screen's now, and
+      moved into the SPA's own styling once nothing server-rendered mounted it.
+- [x] **B6** ✅ Invoices list + detail + line-item editor; PDF links point at
+      the existing Rails routes.
+- [x] **B7** ✅ Offers list + detail + line-item editor + state transitions —
+      see what it turned up, below.
+- [x] **B8** ✅ Expenses + expense import wizard + dashboard + settings tabs +
       backend admin.
 
 Exit per PR: the ported screen has no server-rendered ERB left, Playwright
@@ -657,11 +659,49 @@ changing a response shape:
   authorize `:transition` rather than `:update` — otherwise re-bidding a
   declined offer, which the machine allows, would be unreachable.
 
+#### What B8 turned up
+
+The one-line description said "expenses + import wizard + dashboard + settings
+tabs + backend admin". Four of those five hid something the screens did not
+advertise:
+
+- **The app had two dashboards.** The SPA's landed in B8, but `/` kept
+  rendering the server-rendered one — so signing in through the old form
+  reached the older of the two. Measured, not assumed: `GET /` with a session
+  answered 200 with `id="dashboard"`.
+- **The import dropped the `id` on both legs.** `ExpenseImport` has always
+  looked a row's id up and updated that expense, which is what the screen's own
+  hint promises about a CSV exported from Reckoning — but the API neither sent
+  it out of the preview nor took it back, so every import through it created
+  records.
+- **The backend's "new user" button could never work.** Its form asked for an
+  address and permitted no `account`, which `User` requires. And the endpoint
+  that replaced it suppressed the confirmation mail while the comment above it
+  said it was sending one, which left a created user with no way in at all.
+- **The backend dashboard's second panel printed
+  `Rails.application.credentials`**, with a translation naming one of those keys
+  "SMTP Passwort oder Token". It renders nothing today — flat keys, nested
+  filter — so it is a leak waiting for a rename rather than one in progress. It
+  is not ported.
+
+Two of those were only visible by comparing the screens against the code that
+served them. The lesson from B7 held: what a phase deletes reaches further than
+its one-line description.
+
 ### Phase C — legacy removal (multi-PR, ~1 week)
 
 Only once B8 has landed and stabilized.
 
-- [ ] Catch-all route → SPA shell; delete `SpaController`'s `/app` stub.
+- [x] Catch-all route → SPA shell, and the `/app` prefix is gone: nothing had
+      been deployed, so the SPA answers the paths the server-rendered screens
+      had. The reserved first segments are listed beside the route.
+- [x] Delete `app/assets/javascripts/angular/`, `app/views/templates/`,
+      `TemplatesController`, the vendored Highcharts copy and the d3 / nvd3 /
+      underscore requires.
+- [ ] The rest of `app/assets/` — blocked, not forgotten: the welcome page
+      needs jQuery and Bootstrap's modal, and `/signup` drives Stripe Checkout
+      from `signup.coffee.erb`. Those two, and the three empty legal pages,
+      are a product decision rather than a port.
 - [ ] Delete `app/assets/javascripts/`, `app/assets/stylesheets/`,
       `app/views/templates/`, `TemplatesController`, `vendor/` bower bundles.
 - [ ] Delete `app/frontend/controllers/*_controller.ts` (Stimulus) and


### PR DESCRIPTION
The part of phase C that needs no decisions: the repo's own instructions no
longer match the repo.

`AGENTS.md` still told an agent that **Turbo Drive owns navigation**, that
**Turbo Frames wrap the index pages** in `app/views/{projects,offers,invoices}`
— views that were deleted screens ago — and that **AngularJS lives under
`app/assets/javascripts/angular/`**, which #1024 removed. It is the first file
any of us reads, so being wrong there is expensive.

It now carries:

- where the SPA's pieces live, and that `components/ui` is a measured port of
  Bootstrap 3 rather than a new design system;
- what stays server-rendered **on purpose** (PDFs, exports, mailers, Sidekiq,
  Flipper) and what stays **undecided** (welcome, signup with its Stripe
  Checkout, the three empty legal pages) — with the warning that those three
  are what keeps `app/assets/` alive, so it must not be deleted yet;
- four conventions that are easy to get wrong and cost me time this week: the
  API is declared before the screen exists (a route without a DSL declaration
  is unreachable — that bit twice), Rails owns a path or the SPA does, a
  screen's state lives in the URL, and a look is measured against the still-built
  `application.css` rather than guessed.

`docs/vue-spa-migration-plan.md` gets B2–B8 ticked off, phase C's landed items
marked, and a "what B8 turned up" note in the style the plan already uses for
B7: the app having had two dashboards, the import that could not update a row,
the backend button that could never save, and the panel that would have printed
the SMTP password.

Documentation only — no code. The `meta.requiresAdmin` / `meta.backend` line
assumes #1027, which is in the merge queue. 🤖