### PR TITLE
fix(expenses): offer no copy until there is something to copy

### DIFF
--- a/app/frontend/pages/expenses/ExpenseForm.spec.ts
+++ b/app/frontend/pages/expenses/ExpenseForm.spec.ts
@@ -38,6 +38,8 @@ interface Options {
   path?: string
   expense?: Record<string, unknown>
   refuseReceipt?: boolean
+  /** Leaves the record's request unanswered, as a slow network would. */
+  slow?: boolean
 }
 
 async function mountForm(options: Options = {}) {
@@ -45,6 +47,10 @@ async function mountForm(options: Options = {}) {
 
   AXIOS_INSTANCE.defaults.adapter = async (config) => {
     requests.push(config)
+
+    if (options.slow && String(config.url).includes(`/expenses/${ID}`)) {
+      await new Promise(() => {})
+    }
 
     const url = String(config.url)
     let data: unknown = {}
@@ -100,6 +106,16 @@ async function body(requests: AxiosRequestConfig[], method: "post" | "patch") {
 }
 
 describe("ExpenseForm", () => {
+  // The flake that led here: the copy link was offered while the record was
+  // still on its way, and `copyQuery` had nothing to copy — so "copy" opened
+  // an empty form that looked like one.
+  it("offers no copy until there is something to copy", async () => {
+    const pending = mountForm({path: `/expenses/${ID}/edit`, slow: true})
+    const {wrapper} = await pending
+
+    expect(wrapper.find('[data-test="copy"]').exists()).toBe(false)
+  })
+
   afterEach(() => {
     delete AXIOS_INSTANCE.defaults.adapter
     vi.restoreAllMocks()

--- a/app/frontend/pages/expenses/ExpenseForm.vue
+++ b/app/frontend/pages/expenses/ExpenseForm.vue
@@ -396,7 +396,10 @@ const FIELD = "bs-input"
         <RouterLink :to="{ name: 'expenses', query: listQuery }" data-test="back">
           <UiButton as="span">{{ t("expenseForm.back") }}</UiButton>
         </RouterLink>
-        <template v-if="editing">
+        <!-- Not while the record is still on its way: `copyQuery` has nothing
+             to copy yet, so the link would open an empty form that looks like
+             a copy. -->
+        <template v-if="editing && expense">
           <RouterLink :to="{ name: 'expense-new', query: copyQuery }" data-test="copy">
             <UiButton as="span" variant="warning">
               <i class="fa fa-copy"></i>


### PR DESCRIPTION
The e2e suite has been failing on `Expenses › copies an expense into a new
one` about once every three full runs, and passing in isolation every time. It
was not the test.

`copyQuery` falls back to the list's filters when the record has not arrived,
and the copy link is rendered before it does — so a click in that window opens
`/expenses/new` with no query at all: **an empty form that looks like a copy of
the expense you were reading.** The failure artefact shows exactly that:
expected `/expenses/new?…`, received `/expenses/new`.

The link now waits for the record. Playwright's own actionability wait then
makes the existing e2e deterministic — five consecutive runs of the expenses
spec, all green, where before it failed roughly one run in three.

Covered by a Vitest case that leaves the record's request unanswered and
asserts there is no copy link to click. 🤖