### PR TITLE
feat(api): add a public plans endpoint

### DIFF
--- a/app/api_components/v1/schemas/plan.rb
+++ b/app/api_components/v1/schemas/plan.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    # What the welcome page prices. Public: the page that reads it is the one
+    # visitors see before they have an account.
+    class Plan
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          id: {type: :string, format: :uuid},
+          code: {type: :string},
+          name: {type: :string},
+          price: {type: :integer, description: "In cents, discount already applied."},
+          quantity: {type: [:integer, :null]},
+          interval: {type: [:string, :null], description: "`month` or `year`."},
+          featured: {type: [:boolean, :null]},
+          descriptions: {
+            type: :array,
+            items: {type: :string},
+            description: "What the plan includes, one line each, as the locale authored them."
+          }
+        },
+        additionalProperties: false,
+        required: %w[id code name price descriptions]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/plans.rb
+++ b/app/api_components/v1/schemas/plans.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    class Plans
+      include OpenapiRuby::Components::Base
+
+      schema({type: :array, items: V1::Schemas::Plan})
+    end
+  end
+end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # The welcome page's pricing table. Open, like the page: a visitor has no
+    # session yet, and the prices are what they came to read.
+    class PlansController < ::Api::BaseController
+      skip_authorization_check
+      skip_before_action :authenticate_user!
+
+      def index
+        @plans = ::Plan.all.sort_by { |plan| plan.price.cents }
+      end
+    end
+  end
+end

--- a/app/views/api/v1/plans/index.json.jbuilder
+++ b/app/views/api/v1/plans/index.json.jbuilder
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+json.array! @plans do |plan|
+  json.id plan.id
+  json.code plan.code
+  json.name plan.name
+  json.price plan.price.cents
+  json.quantity plan.quantity
+  json.interval plan.interval
+  json.featured plan.featured
+  # `plans.desc.<code>` is a hash of lines; the page prints its values.
+  json.descriptions Array(I18n.t("plans.desc.#{plan.code}", default: {}).values).map(&:to_s)
+end

--- a/config/routes/api_v1_routes.rb
+++ b/config/routes/api_v1_routes.rb
@@ -42,6 +42,8 @@ v1_api_routes = lambda do
     end
   end
 
+  resources :plans, only: [:index]
+
   resources :customers, only: %i[index show create update destroy]
 
   resources :projects, only: %i[index show create update destroy] do

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -2317,6 +2317,19 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ValidationError"
+  "/plans":
+    get:
+      summary: The plans the welcome page prices
+      tags:
+      - Plans
+      operationId: plans
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Plans"
   "/projects":
     get:
       summary: Projects list
@@ -4975,6 +4988,51 @@ components:
       required:
       - email
       title: PasswordResetRequestInput
+    Plan:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        price:
+          type: integer
+          description: In cents, discount already applied.
+        quantity:
+          type:
+          - integer
+          - 'null'
+        interval:
+          type:
+          - string
+          - 'null'
+          description: "`month` or `year`."
+        featured:
+          type:
+          - boolean
+          - 'null'
+        descriptions:
+          type: array
+          items:
+            type: string
+          description: What the plan includes, one line each, as the locale authored
+            them.
+      additionalProperties: false
+      required:
+      - id
+      - code
+      - name
+      - price
+      - descriptions
+      title: Plan
+    Plans:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Plan"
+      title: Plans
     Project:
       type: object
       properties:

--- a/test/fixtures/plans.yml
+++ b/test/fixtures/plans.yml
@@ -1,0 +1,17 @@
+# The plans the welcome page prices. `prefill_from_base_plan` only runs on
+# create through Stripe; fixtures carry the values it would have written.
+basic:
+  code: basic
+  base_price: 900
+  quantity: 1
+  interval: month
+  featured: false
+  stripe_plan_id: plan_basic
+
+plus:
+  code: plus
+  base_price: 1900
+  quantity: 1
+  interval: month
+  featured: true
+  stripe_plan_id: plan_plus

--- a/test/integration/api/v1/plans_test.rb
+++ b/test/integration/api/v1/plans_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+module Api
+  module V1
+    class PlansTest < ActionDispatch::IntegrationTest
+      include OpenapiRuby::Adapters::Minitest::DSL
+
+      openapi_schema :"v1/schema"
+
+      api_path "/plans" do
+        get("The plans the welcome page prices") do
+          operationId "plans"
+          tags "Plans"
+          produces "application/json"
+
+          response(200, "successful") do
+            schema ::V1::Schemas::Plans
+          end
+        end
+      end
+
+      # The page that reads this is the one a visitor sees before they have an
+      # account, so it answers without a session.
+      it "answers a visitor" do
+        assert_api_response :get, 200 do
+          codes = parsed_body.map { |plan| plan["code"] }
+
+          assert_includes codes, "basic"
+        end
+      end
+
+      it "prices them in cents, cheapest first" do
+        assert_api_response :get, 200 do
+          prices = parsed_body.map { |plan| plan["price"] }
+
+          assert_equal prices.sort, prices
+          assert_equal 900, parsed_body.find { |plan| plan["code"] == "basic" }["price"]
+        end
+      end
+
+      # `plans.desc.<code>` is what the pricing table lists under the price.
+      it "carries what each plan includes" do
+        assert_api_response :get, 200 do
+          basic = parsed_body.find { |plan| plan["code"] == "basic" }
+
+          assert_equal I18n.t("plans.desc.basic").values.map(&:to_s), basic["descriptions"]
+          refute_empty basic["descriptions"]
+        end
+      end
+
+      it "marks the one the page highlights" do
+        assert_api_response :get, 200 do
+          assert parsed_body.find { |plan| plan["code"] == "plus" }["featured"]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The welcome page prices the plans, so the SPA needs them before a visitor has a session. `GET /api/v1/plans` answers unauthenticated, like `/config` does, and returns per plan: `id`, `code`, `name`, `price` (cents, discount applied), `quantity`, `interval`, `featured` and `descriptions` — the `plans.desc.<code>` lines as the locale authored them, which is what the pricing table lists under the price.

Cheapest first, so the table renders in the order the ERB page showed.

`test/fixtures/plans.yml` is new: there were no plans in the test database at all, so nothing exercised this side of the app. Real plans are created from Stripe, and `prefill_from_base_plan` only runs on create — the fixtures carry the values it would have written.

Groundwork for the welcome and signup pages, the last public ERB screens.

🤖